### PR TITLE
Use the package's name in the branch name when updating the version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -139,3 +139,4 @@ jobs:
         uses: ni/python-actions/update-project-version@5286c12d65d90b2ea738bd57d452dc4366497581 # v0.4.1
         with:
           project-directory: ./packages/${{ needs.get_package_info.outputs.package-name }}
+          branch-prefix: users/build/${{ needs.get_package_info.outputs.package-name }}-


### PR DESCRIPTION
### What does this Pull Request accomplish?

This change sets the `branch-prefix` to include the package's name to keep update-version PR branch names unique.

### Why should this Pull Request be merged?

When we publish multiple packages together, [the automation that updates each package's version](https://github.com/ni/ni-apis-python/actions/runs/16807606116/job/47604977885) uses the same branch name to do so, and the last package that it updates reverts the previous version updates.

```
From https://github.com/ni/ni-apis-python
   * [new branch]      users/build/update-project-version-main -> origin/users/build/update-project-version-main
  Pull request branch 'users/build/update-project-version-main' already exists as remote branch 'origin/users/build/update-project-version-main'

...

Reset branch 'users/build/update-project-version-main'
  Your branch and 'origin/users/build/update-project-version-main' have diverged,
  and have 1 and 1 different commits each, respectively.

...

Pushing pull request branch to 'origin/users/build/update-project-version-main'
  /usr/bin/git push --force-with-lease origin users/build/update-project-version-main:refs/heads/users/build/update-project-version-main
  To https://github.com/ni/ni-apis-python
   + 4503b7d...5043547 users/build/update-project-version-main -> users/build/update-project-version-main (forced update)

...

Attempting creation of pull request
  A pull request already exists for ni:users/build/update-project-version-main
  Fetching existing pull request
  Attempting update of pull request
  Updated pull request #47 (ni:users/build/update-project-version-main => main)
```

### What testing has been done?

None