### PR TITLE
Fix the paths in the readthedocs files to allow for successful RTD build.

### DIFF
--- a/packages/ni.panels.v1.proto/.readthedocs.yaml
+++ b/packages/ni.panels.v1.proto/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
     post_create_environment:
       - pip install poetry==1.8.2
     post_install:
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --only main,docs
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry -C packages/ni.panels.v1.proto install --only main,docs
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: packages/ni.panels.v1.proto/docs/conf.py

--- a/packages/ni.protobuf.types/.readthedocs.yaml
+++ b/packages/ni.protobuf.types/.readthedocs.yaml
@@ -13,4 +13,4 @@ build:
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry -C packages/ni.protobuf.types install --only main,docs
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: packages/ni.protobuf.types/docs/conf.py

--- a/packages/ni.protobuf.types/.readthedocs.yaml
+++ b/packages/ni.protobuf.types/.readthedocs.yaml
@@ -10,7 +10,7 @@ build:
     post_create_environment:
       - pip install poetry==1.8.2
     post_install:
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --only main,docs
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry -C packages/ni.protobuf.types install --only main,docs
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Use `poetry -C` to change the working directory of the poetry command.
- Update the path to the `conf.py` file.

### Why should this Pull Request be merged?

To get ReadTheDocs working.

### What testing has been done?

The `ni.protobuf.types` build succeeds on this branch.
<img width="440" height="487" alt="image" src="https://github.com/user-attachments/assets/dd01d082-c85b-4be8-9c15-1c639e1fff0b" />
