### PR TITLE
Users/mjohanse/lint grpc gen

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,13 +25,14 @@ jobs:
   check_analyzers_grpc_gen:
     name: Check analyzers for grpc_generator
     uses: ./.github/workflows/check_analyzers.yml
+    needs: [check_package]
     with:
       package-name: grpc_generator
       package-base-path: tools
   run_unit_tests:
     name: Run unit tests
     uses: ./.github/workflows/run_unit_tests.yml
-    needs: [check_package]
+    needs: [check_analyzers_grpc_gen]
   report_test_results:
     name: Report test results
     uses: ./.github/workflows/report_test_results.yml

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,12 @@ jobs:
     with:
       package-name: ${{ matrix.package-name }}
       proto-subpath: ${{ matrix.proto-subpath }}
+  check_analyzers_grpc_gen:
+    name: Check analyzers for grpc_generator
+    uses: ./.github/workflows/check_analyzers.yml
+    with:
+      package-name: grpc_generator
+      package-base-path: tools
   run_unit_tests:
     name: Run unit tests
     uses: ./.github/workflows/run_unit_tests.yml

--- a/.github/workflows/check_analyzers.yml
+++ b/.github/workflows/check_analyzers.yml
@@ -8,6 +8,11 @@ on:
         default: ''
         required: true
         type: string
+      package-base-path:
+        description: 'The parent directory of the package to check. Defaults to packages.'
+        default: 'packages'
+        required: false
+        type: string
 
 jobs:
   check_analyzers:
@@ -16,7 +21,7 @@ jobs:
     defaults:
       run:
         # Set the working-directory for all steps in this job.
-        working-directory: ./packages/${{ inputs.package-name }}
+        working-directory: ./${{ inputs.package-base-path }}/${{ inputs.package-name }}
     steps:
       - name: Check out repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -32,8 +37,8 @@ jobs:
       - name: Cache virtualenv
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          path: packages/${{ inputs.package-name }}/.venv
-          key: ${{ inputs.package-name }}-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles(format('packages/{0}/poetry.lock', inputs.package-name)) }}
+          path: ${{ inputs.package-base-path }}/${{ inputs.package-name }}/.venv
+          key: ${{ inputs.package-name }}-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles(format('{0}/{1}/poetry.lock', inputs.package-base-path, inputs.package-name)) }}
       - name: Install ${{ inputs.package-name }}
         run: poetry install -v
       - name: Lint
@@ -51,10 +56,10 @@ jobs:
         with:
           python-platform: Linux
           version: PATH
-          working-directory: ./packages/${{ inputs.package-name }}
+          working-directory: ./${{ inputs.package-base-path }}/${{ inputs.package-name }}
       - name: Pyright static analysis (Windows)
         uses: jakebailey/pyright-action@b5d50e5cde6547546a5c4ac92e416a8c2c1a1dfe # v2.3.2
         with:
           python-platform: Windows
           version: PATH
-          working-directory: ./packages/${{ inputs.package-name }}
+          working-directory: ./${{ inputs.package-base-path }}/${{ inputs.package-name }}


### PR DESCRIPTION
### What does this Pull Request accomplish?

Updates `check_analyzers.yml` to have a second input: `package-base-path` so that we can run the analyzers on `tools/grpc_generator`. The default is `packages` to keep compatibility with the current users of `check_analyzers`.
Adds a job to the CI workflow that runs the analyzers on `grpc_generator`.
Adjusts `needs` statements to ensure workflow order.

### Why should this Pull Request be merged?

Fixes AB#3225008

### What testing has been done?

PR/CI checks run as part of this PR.
