### PR TITLE
Fix ni.grpcdevice.v1.proto to have session_pb2 and session_pb2_grpc packages at the top level

### DIFF
--- a/packages/ni.grpcdevice.v1.proto/pyproject.toml
+++ b/packages/ni.grpcdevice.v1.proto/pyproject.toml
@@ -27,7 +27,10 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
-packages = [{include = "src"}]
+packages = [
+  {include = "session_pb2", from = "src"},
+  {include = "session_pb2_grpc", from = "src"},
+]
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes ni.grpcdevice.v1.proto so its contents have session_pb2 and session_pb2_grpc as top-level packages. They were under 'src/session_pb2' prior to this.

### Why should this Pull Request be merged?

For backwards compatibility we need to be able to do `import session_pb2`.

### What testing has been done?

Built the .whl locally and installed.
```
>>> import session_pb2
>>> session_pb2.Session
<class 'session_pb2.Session'>
```