### PR TITLE
Fix session.proto namespace and regenerate python code

### DIFF
--- a/packages/ni.grpcdevice.v1.proto/src/session_pb2/__init__.py
+++ b/packages/ni.grpcdevice.v1.proto/src/session_pb2/__init__.py
@@ -13,7 +13,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rsession.proto\x12\x10ni.grpcdevice.v1\"2\n\x07Session\x12\x0e\n\x04name\x18\x01 \x01(\tH\x00\x12\x0c\n\x02id\x18\x02 \x01(\rH\x00\x42\t\n\x07session\"j\n\x10\x44\x65viceProperties\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05model\x18\x02 \x01(\t\x12\x0e\n\x06vendor\x18\x03 \x01(\t\x12\x15\n\rserial_number\x18\x04 \x01(\t\x12\x12\n\nproduct_id\x18\x05 \x01(\r\"\x19\n\x17\x45numerateDevicesRequest\"O\n\x18\x45numerateDevicesResponse\x12\x33\n\x07\x64\x65vices\x18\x01 \x03(\x0b\x32\".ni.grpcdevice.v1.DeviceProperties\";\n\x0eReserveRequest\x12\x16\n\x0ereservation_id\x18\x01 \x01(\t\x12\x11\n\tclient_id\x18\x02 \x01(\t\"&\n\x0fReserveResponse\x12\x13\n\x0bis_reserved\x18\x01 \x01(\x08\"F\n\x19IsReservedByClientRequest\x12\x16\n\x0ereservation_id\x18\x01 \x01(\t\x12\x11\n\tclient_id\x18\x02 \x01(\t\"1\n\x1aIsReservedByClientResponse\x12\x13\n\x0bis_reserved\x18\x01 \x01(\x08\"=\n\x10UnreserveRequest\x12\x16\n\x0ereservation_id\x18\x01 \x01(\t\x12\x11\n\tclient_id\x18\x02 \x01(\t\"*\n\x11UnreserveResponse\x12\x15\n\ris_unreserved\x18\x01 \x01(\x08\"\x14\n\x12ResetServerRequest\".\n\x13ResetServerResponse\x12\x17\n\x0fis_server_reset\x18\x01 \x01(\x08*\xbc\x01\n\x1dSessionInitializationBehavior\x12/\n+SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED\x10\x00\x12\x32\n.SESSION_INITIALIZATION_BEHAVIOR_INITIALIZE_NEW\x10\x01\x12\x36\n2SESSION_INITIALIZATION_BEHAVIOR_ATTACH_TO_EXISTING\x10\x02\x32\xf0\x03\n\x10SessionUtilities\x12i\n\x10\x45numerateDevices\x12).ni.grpcdevice.v1.EnumerateDevicesRequest\x1a*.ni.grpcdevice.v1.EnumerateDevicesResponse\x12N\n\x07Reserve\x12 .ni.grpcdevice.v1.ReserveRequest\x1a!.ni.grpcdevice.v1.ReserveResponse\x12o\n\x12IsReservedByClient\x12+.ni.grpcdevice.v1.IsReservedByClientRequest\x1a,.ni.grpcdevice.v1.IsReservedByClientResponse\x12T\n\tUnreserve\x12\".ni.grpcdevice.v1.UnreserveRequest\x1a#.ni.grpcdevice.v1.UnreserveResponse\x12Z\n\x0bResetServer\x12$.ni.grpcdevice.v1.ResetServerRequest\x1a%.ni.grpcdevice.v1.ResetServerResponseBB\n\x12\x63om.ni.grpc.deviceB\x08NiDeviceP\x01\xaa\x02\x1fNationalInstruments.Grpc.Deviceb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rsession.proto\x12\rnidevice_grpc\"2\n\x07Session\x12\x0e\n\x04name\x18\x01 \x01(\tH\x00\x12\x0c\n\x02id\x18\x02 \x01(\rH\x00\x42\t\n\x07session\"j\n\x10\x44\x65viceProperties\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05model\x18\x02 \x01(\t\x12\x0e\n\x06vendor\x18\x03 \x01(\t\x12\x15\n\rserial_number\x18\x04 \x01(\t\x12\x12\n\nproduct_id\x18\x05 \x01(\r\"\x19\n\x17\x45numerateDevicesRequest\"L\n\x18\x45numerateDevicesResponse\x12\x30\n\x07\x64\x65vices\x18\x01 \x03(\x0b\x32\x1f.nidevice_grpc.DeviceProperties\";\n\x0eReserveRequest\x12\x16\n\x0ereservation_id\x18\x01 \x01(\t\x12\x11\n\tclient_id\x18\x02 \x01(\t\"&\n\x0fReserveResponse\x12\x13\n\x0bis_reserved\x18\x01 \x01(\x08\"F\n\x19IsReservedByClientRequest\x12\x16\n\x0ereservation_id\x18\x01 \x01(\t\x12\x11\n\tclient_id\x18\x02 \x01(\t\"1\n\x1aIsReservedByClientResponse\x12\x13\n\x0bis_reserved\x18\x01 \x01(\x08\"=\n\x10UnreserveRequest\x12\x16\n\x0ereservation_id\x18\x01 \x01(\t\x12\x11\n\tclient_id\x18\x02 \x01(\t\"*\n\x11UnreserveResponse\x12\x15\n\ris_unreserved\x18\x01 \x01(\x08\"\x14\n\x12ResetServerRequest\".\n\x13ResetServerResponse\x12\x17\n\x0fis_server_reset\x18\x01 \x01(\x08*\xbc\x01\n\x1dSessionInitializationBehavior\x12/\n+SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED\x10\x00\x12\x32\n.SESSION_INITIALIZATION_BEHAVIOR_INITIALIZE_NEW\x10\x01\x12\x36\n2SESSION_INITIALIZATION_BEHAVIOR_ATTACH_TO_EXISTING\x10\x02\x32\xd2\x03\n\x10SessionUtilities\x12\x63\n\x10\x45numerateDevices\x12&.nidevice_grpc.EnumerateDevicesRequest\x1a\'.nidevice_grpc.EnumerateDevicesResponse\x12H\n\x07Reserve\x12\x1d.nidevice_grpc.ReserveRequest\x1a\x1e.nidevice_grpc.ReserveResponse\x12i\n\x12IsReservedByClient\x12(.nidevice_grpc.IsReservedByClientRequest\x1a).nidevice_grpc.IsReservedByClientResponse\x12N\n\tUnreserve\x12\x1f.nidevice_grpc.UnreserveRequest\x1a .nidevice_grpc.UnreserveResponse\x12T\n\x0bResetServer\x12!.nidevice_grpc.ResetServerRequest\x1a\".nidevice_grpc.ResetServerResponseBB\n\x12\x63om.ni.grpc.deviceB\x08NiDeviceP\x01\xaa\x02\x1fNationalInstruments.Grpc.Deviceb\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'session_pb2', globals())
@@ -21,32 +21,32 @@ if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
   DESCRIPTOR._serialized_options = b'\n\022com.ni.grpc.deviceB\010NiDeviceP\001\252\002\037NationalInstruments.Grpc.Device'
-  _SESSIONINITIALIZATIONBEHAVIOR._serialized_start=705
-  _SESSIONINITIALIZATIONBEHAVIOR._serialized_end=893
-  _SESSION._serialized_start=35
-  _SESSION._serialized_end=85
-  _DEVICEPROPERTIES._serialized_start=87
-  _DEVICEPROPERTIES._serialized_end=193
-  _ENUMERATEDEVICESREQUEST._serialized_start=195
-  _ENUMERATEDEVICESREQUEST._serialized_end=220
-  _ENUMERATEDEVICESRESPONSE._serialized_start=222
-  _ENUMERATEDEVICESRESPONSE._serialized_end=301
-  _RESERVEREQUEST._serialized_start=303
-  _RESERVEREQUEST._serialized_end=362
-  _RESERVERESPONSE._serialized_start=364
-  _RESERVERESPONSE._serialized_end=402
-  _ISRESERVEDBYCLIENTREQUEST._serialized_start=404
-  _ISRESERVEDBYCLIENTREQUEST._serialized_end=474
-  _ISRESERVEDBYCLIENTRESPONSE._serialized_start=476
-  _ISRESERVEDBYCLIENTRESPONSE._serialized_end=525
-  _UNRESERVEREQUEST._serialized_start=527
-  _UNRESERVEREQUEST._serialized_end=588
-  _UNRESERVERESPONSE._serialized_start=590
-  _UNRESERVERESPONSE._serialized_end=632
-  _RESETSERVERREQUEST._serialized_start=634
-  _RESETSERVERREQUEST._serialized_end=654
-  _RESETSERVERRESPONSE._serialized_start=656
-  _RESETSERVERRESPONSE._serialized_end=702
-  _SESSIONUTILITIES._serialized_start=896
-  _SESSIONUTILITIES._serialized_end=1392
+  _SESSIONINITIALIZATIONBEHAVIOR._serialized_start=699
+  _SESSIONINITIALIZATIONBEHAVIOR._serialized_end=887
+  _SESSION._serialized_start=32
+  _SESSION._serialized_end=82
+  _DEVICEPROPERTIES._serialized_start=84
+  _DEVICEPROPERTIES._serialized_end=190
+  _ENUMERATEDEVICESREQUEST._serialized_start=192
+  _ENUMERATEDEVICESREQUEST._serialized_end=217
+  _ENUMERATEDEVICESRESPONSE._serialized_start=219
+  _ENUMERATEDEVICESRESPONSE._serialized_end=295
+  _RESERVEREQUEST._serialized_start=297
+  _RESERVEREQUEST._serialized_end=356
+  _RESERVERESPONSE._serialized_start=358
+  _RESERVERESPONSE._serialized_end=396
+  _ISRESERVEDBYCLIENTREQUEST._serialized_start=398
+  _ISRESERVEDBYCLIENTREQUEST._serialized_end=468
+  _ISRESERVEDBYCLIENTRESPONSE._serialized_start=470
+  _ISRESERVEDBYCLIENTRESPONSE._serialized_end=519
+  _UNRESERVEREQUEST._serialized_start=521
+  _UNRESERVEREQUEST._serialized_end=582
+  _UNRESERVERESPONSE._serialized_start=584
+  _UNRESERVERESPONSE._serialized_end=626
+  _RESETSERVERREQUEST._serialized_start=628
+  _RESETSERVERREQUEST._serialized_end=648
+  _RESETSERVERRESPONSE._serialized_start=650
+  _RESETSERVERRESPONSE._serialized_end=696
+  _SESSIONUTILITIES._serialized_start=890
+  _SESSIONUTILITIES._serialized_end=1356
 # @@protoc_insertion_point(module_scope)

--- a/packages/ni.grpcdevice.v1.proto/src/session_pb2_grpc/__init__.py
+++ b/packages/ni.grpcdevice.v1.proto/src/session_pb2_grpc/__init__.py
@@ -15,27 +15,27 @@ class SessionUtilitiesStub(object):
             channel: A grpc.Channel.
         """
         self.EnumerateDevices = channel.unary_unary(
-                '/ni.grpcdevice.v1.SessionUtilities/EnumerateDevices',
+                '/nidevice_grpc.SessionUtilities/EnumerateDevices',
                 request_serializer=session__pb2.EnumerateDevicesRequest.SerializeToString,
                 response_deserializer=session__pb2.EnumerateDevicesResponse.FromString,
                 )
         self.Reserve = channel.unary_unary(
-                '/ni.grpcdevice.v1.SessionUtilities/Reserve',
+                '/nidevice_grpc.SessionUtilities/Reserve',
                 request_serializer=session__pb2.ReserveRequest.SerializeToString,
                 response_deserializer=session__pb2.ReserveResponse.FromString,
                 )
         self.IsReservedByClient = channel.unary_unary(
-                '/ni.grpcdevice.v1.SessionUtilities/IsReservedByClient',
+                '/nidevice_grpc.SessionUtilities/IsReservedByClient',
                 request_serializer=session__pb2.IsReservedByClientRequest.SerializeToString,
                 response_deserializer=session__pb2.IsReservedByClientResponse.FromString,
                 )
         self.Unreserve = channel.unary_unary(
-                '/ni.grpcdevice.v1.SessionUtilities/Unreserve',
+                '/nidevice_grpc.SessionUtilities/Unreserve',
                 request_serializer=session__pb2.UnreserveRequest.SerializeToString,
                 response_deserializer=session__pb2.UnreserveResponse.FromString,
                 )
         self.ResetServer = channel.unary_unary(
-                '/ni.grpcdevice.v1.SessionUtilities/ResetServer',
+                '/nidevice_grpc.SessionUtilities/ResetServer',
                 request_serializer=session__pb2.ResetServerRequest.SerializeToString,
                 response_deserializer=session__pb2.ResetServerResponse.FromString,
                 )
@@ -110,7 +110,7 @@ def add_SessionUtilitiesServicer_to_server(servicer, server):
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
-            'ni.grpcdevice.v1.SessionUtilities', rpc_method_handlers)
+            'nidevice_grpc.SessionUtilities', rpc_method_handlers)
     server.add_generic_rpc_handlers((generic_handler,))
 
 
@@ -129,7 +129,7 @@ class SessionUtilities(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/ni.grpcdevice.v1.SessionUtilities/EnumerateDevices',
+        return grpc.experimental.unary_unary(request, target, '/nidevice_grpc.SessionUtilities/EnumerateDevices',
             session__pb2.EnumerateDevicesRequest.SerializeToString,
             session__pb2.EnumerateDevicesResponse.FromString,
             options, channel_credentials,
@@ -146,7 +146,7 @@ class SessionUtilities(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/ni.grpcdevice.v1.SessionUtilities/Reserve',
+        return grpc.experimental.unary_unary(request, target, '/nidevice_grpc.SessionUtilities/Reserve',
             session__pb2.ReserveRequest.SerializeToString,
             session__pb2.ReserveResponse.FromString,
             options, channel_credentials,
@@ -163,7 +163,7 @@ class SessionUtilities(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/ni.grpcdevice.v1.SessionUtilities/IsReservedByClient',
+        return grpc.experimental.unary_unary(request, target, '/nidevice_grpc.SessionUtilities/IsReservedByClient',
             session__pb2.IsReservedByClientRequest.SerializeToString,
             session__pb2.IsReservedByClientResponse.FromString,
             options, channel_credentials,
@@ -180,7 +180,7 @@ class SessionUtilities(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/ni.grpcdevice.v1.SessionUtilities/Unreserve',
+        return grpc.experimental.unary_unary(request, target, '/nidevice_grpc.SessionUtilities/Unreserve',
             session__pb2.UnreserveRequest.SerializeToString,
             session__pb2.UnreserveResponse.FromString,
             options, channel_credentials,
@@ -197,7 +197,7 @@ class SessionUtilities(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/ni.grpcdevice.v1.SessionUtilities/ResetServer',
+        return grpc.experimental.unary_unary(request, target, '/nidevice_grpc.SessionUtilities/ResetServer',
             session__pb2.ResetServerRequest.SerializeToString,
             session__pb2.ResetServerResponse.FromString,
             options, channel_credentials,

--- a/proto/session.proto
+++ b/proto/session.proto
@@ -5,7 +5,7 @@ option java_package = "com.ni.grpc.device";
 option java_outer_classname = "NiDevice";
 option csharp_namespace = "NationalInstruments.Grpc.Device";
 
-package ni.grpcdevice.v1;
+package nidevice_grpc;
 
 service SessionUtilities {
   // Provides a list of devices or chassis connected to server under localhost


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes the namespace of our session.proto file and regenerates the stubs for ni.grpcdevice.v1.proto.

### Why should this Pull Request be merged?

I had mistakenly changed the package namespace to ni.grpcdevice.v1. But it needs to be nidevice_grpc for backwards compatibility.

### What testing has been done?

Will produce a new version of the package and test with that after submission.
