### PR TITLE
Add PrecisionDuration conversion functions

### DIFF
--- a/packages/ni.protobuf.types/src/ni/protobuf/types/precision_duration_conversion.py
+++ b/packages/ni.protobuf.types/src/ni/protobuf/types/precision_duration_conversion.py
@@ -1,0 +1,36 @@
+"""Methods to convert to and from PrecisionDuration protobuf messages."""
+
+from __future__ import annotations
+
+import hightime as ht
+import nitypes.bintime as bt
+from nitypes.time import convert_timedelta
+
+from ni.protobuf.types.precision_duration_pb2 import (
+    PrecisionDuration,
+)
+
+
+def bintime_timedelta_to_protobuf(value: bt.TimeDelta, /) -> PrecisionDuration:
+    """Convert a NI-BTF TimeDelta to a protobuf PrecisionDuration."""
+    seconds, fractional_seconds = value.to_tuple()
+    return PrecisionDuration(seconds=seconds, fractional_seconds=fractional_seconds)
+
+
+def bintime_timedelta_from_protobuf(message: PrecisionDuration, /) -> bt.TimeDelta:
+    """Convert a protobuf PrecisionDuration to a NI-BTF TimeDelta."""
+    time_value_tuple = bt.TimeValueTuple(message.seconds, message.fractional_seconds)
+    return bt.TimeDelta.from_tuple(time_value_tuple)
+
+
+def hightime_timedelta_to_protobuf(value: ht.timedelta, /) -> PrecisionDuration:
+    """Convert a hightime.timedelta to a protobuf PrecisionDuration."""
+    bt_timedelta = convert_timedelta(bt.TimeDelta, value)
+    return bintime_timedelta_to_protobuf(bt_timedelta)
+
+
+def hightime_timedelta_from_protobuf(message: PrecisionDuration, /) -> ht.timedelta:
+    """Convert a protobuf PrecisionDuration to a hightime.timedelta."""
+    bt_timedelta = bintime_timedelta_from_protobuf(message)
+    ht_timedelta = convert_timedelta(ht.timedelta, bt_timedelta)
+    return ht_timedelta

--- a/packages/ni.protobuf.types/tests/unit/test_precision_duration_conversion.py
+++ b/packages/ni.protobuf.types/tests/unit/test_precision_duration_conversion.py
@@ -1,0 +1,64 @@
+import hightime as ht
+import nitypes.bintime as bt
+from nitypes.time import convert_timedelta
+
+from ni.protobuf.types.precision_duration_conversion import (
+    bintime_timedelta_to_protobuf,
+    bintime_timedelta_from_protobuf,
+    hightime_timedelta_to_protobuf,
+    hightime_timedelta_from_protobuf,
+)
+from ni.protobuf.types.precision_duration_pb2 import PrecisionDuration
+
+
+# ========================================================
+# bintime.TimeDelta <--> PrecisionDuration
+# ========================================================
+def test___precision_duration___convert___valid_bintime_timedelta() -> None:
+    seconds = 25
+    fractional_seconds = 123
+    pts = PrecisionDuration(seconds=seconds, fractional_seconds=fractional_seconds)
+
+    bintime_timedelta = bintime_timedelta_from_protobuf(pts)
+
+    time_value = bintime_timedelta.to_tuple()
+    assert time_value.whole_seconds == seconds
+    assert time_value.fractional_seconds == fractional_seconds
+
+
+def test___bintime_timedelta___convert___valid_precision_duration() -> None:
+    seconds = 25
+    fractional_seconds = 123
+    bintime_timedelta = bt.TimeDelta.from_tuple(bt.TimeValueTuple(seconds, fractional_seconds))
+
+    pts = bintime_timedelta_to_protobuf(bintime_timedelta)
+
+    assert pts.seconds == seconds
+    assert pts.fractional_seconds == fractional_seconds
+
+
+# ========================================================
+# hightime.timedelta <--> PrecisionDuration
+# ========================================================
+def test___precision_duration___convert___valid_hightime_timedelta() -> None:
+    seconds = 25
+    fractional_seconds = 123
+    pts = PrecisionDuration(seconds=seconds, fractional_seconds=fractional_seconds)
+
+    ht_timedelta = hightime_timedelta_from_protobuf(pts)
+
+    bt_timedelta = convert_timedelta(bt.TimeDelta, ht_timedelta)
+    time_value = bt_timedelta.to_tuple()
+    assert time_value.whole_seconds == seconds
+    assert time_value.fractional_seconds == fractional_seconds
+
+
+def test___hightime_timedelta___convert___valid_precision_duration() -> None:
+    ht_timedelta = ht.timedelta(days=1, hours=5, minutes=26, seconds=35, picoseconds=7)
+
+    pts = hightime_timedelta_to_protobuf(ht_timedelta)
+
+    bt_timedelta = convert_timedelta(bt.TimeDelta, ht_timedelta)
+    time_value = bt_timedelta.to_tuple()
+    assert pts.seconds == time_value.whole_seconds
+    assert pts.fractional_seconds == time_value.fractional_seconds


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds conversion functions to/from the `PrecisionDuration` protobuf type. Covers both `hightime.timedelta` and `bintime.TimeDelta`.

### Why should this Pull Request be merged?

Implements parts of AB#3164818

### What testing has been done?

- Added unit tests for the conversion functions
- Unit tests, mypy, pyright, styleguide
