### PR TITLE
feat: Populate Session Annotations with Client Machine details

### DIFF
--- a/packages/ni.measurementlink.sessionmanagement.v1.client/src/ni/measurementlink/sessionmanagement/v1/client/__init__.py
+++ b/packages/ni.measurementlink.sessionmanagement.v1.client/src/ni/measurementlink/sessionmanagement/v1/client/__init__.py
@@ -29,6 +29,12 @@ from ni.measurementlink.sessionmanagement.v1.client._constants import (
     INSTRUMENT_TYPE_NI_SWITCH_EXECUTIVE_VIRTUAL_DEVICE,
     INSTRUMENT_TYPE_NONE,
     SITE_SYSTEM_PINS,
+    RESERVED_HOSTNAME,
+    RESERVED_USERNAME,
+    RESERVED_IPADDRESS,
+    REGISTERED_HOSTNAME,
+    REGISTERED_USERNAME,
+    REGISTERED_IPADDRESS,
 )
 from ni.measurementlink.sessionmanagement.v1.client._reservation import (
     BaseReservation,
@@ -84,6 +90,12 @@ __all__ = [
     "TypedConnectionWithMultiplexer",
     "TypedMultiplexerSessionInformation",
     "TypedSessionInformation",
+    "RESERVED_HOSTNAME",
+    "RESERVED_USERNAME",
+    "RESERVED_IPADDRESS",
+    "REGISTERED_HOSTNAME",
+    "REGISTERED_USERNAME",
+    "REGISTERED_IPADDRESS",
 ]
 
 

--- a/packages/ni.measurementlink.sessionmanagement.v1.client/src/ni/measurementlink/sessionmanagement/v1/client/_constants.py
+++ b/packages/ni.measurementlink.sessionmanagement.v1.client/src/ni/measurementlink/sessionmanagement/v1/client/_constants.py
@@ -30,3 +30,12 @@ belong to a specific site.
 When querying connections, you can specify a site number of ``SITE_SYSTEM_PINS``
 to restrict the query to return only system pins.
 """
+
+# Constants for session client details annotations
+RESERVED_HOSTNAME = "ni/reserved.hostname"
+RESERVED_USERNAME = "ni/reserved.username"
+RESERVED_IPADDRESS = "ni/reserved.ipaddress"
+
+REGISTERED_HOSTNAME = "ni/registered.hostname"
+REGISTERED_USERNAME = "ni/registered.username"
+REGISTERED_IPADDRESS = "ni/registered.ipaddress"

--- a/packages/ni.measurementlink.sessionmanagement.v1.client/src/ni/measurementlink/sessionmanagement/v1/client/_helpers.py
+++ b/packages/ni.measurementlink.sessionmanagement.v1.client/src/ni/measurementlink/sessionmanagement/v1/client/_helpers.py
@@ -1,0 +1,64 @@
+import socket
+
+import win32api
+
+from ni.measurementlink.sessionmanagement.v1.client._constants import (
+    REGISTERED_HOSTNAME,
+    REGISTERED_IPADDRESS,
+    REGISTERED_USERNAME,
+    RESERVED_HOSTNAME,
+    RESERVED_IPADDRESS,
+    RESERVED_USERNAME,
+)
+
+
+def get_machine_details() -> tuple[dict[str, str], dict[str, str]]:
+    """Get the machine details for reserved and registered annotations."""
+    hostname = _get_hostname()
+    username = _get_username()
+    ip_address = _get_ip_address(hostname)
+
+    reserved = {
+        RESERVED_HOSTNAME: hostname,
+        RESERVED_USERNAME: username,
+        RESERVED_IPADDRESS: ip_address,
+    }
+
+    registered = {
+        REGISTERED_HOSTNAME: hostname,
+        REGISTERED_USERNAME: username,
+        REGISTERED_IPADDRESS: ip_address,
+    }
+
+    return reserved, registered
+
+
+def remove_reservation_annotations(annotations: dict[str, str]) -> dict[str, str]:
+    """Remove reserved annotations from the provided annotations."""
+    reservation_keys = {
+        RESERVED_HOSTNAME,
+        RESERVED_USERNAME,
+        RESERVED_IPADDRESS,
+    }
+    return {k: v for k, v in annotations.items() if k not in reservation_keys}
+
+
+def _get_hostname() -> str:
+    try:
+        return win32api.GetComputerName()
+    except Exception:
+        return ""
+
+
+def _get_username() -> str:
+    try:
+        return win32api.GetUserName()
+    except Exception:
+        return ""
+
+
+def _get_ip_address(hostname: str) -> str:
+    try:
+        return socket.gethostbyname(hostname)
+    except Exception:
+        return ""

--- a/packages/ni.measurementlink.sessionmanagement.v1.client/src/ni/measurementlink/sessionmanagement/v1/client/_types.py
+++ b/packages/ni.measurementlink.sessionmanagement.v1.client/src/ni/measurementlink/sessionmanagement/v1/client/_types.py
@@ -139,6 +139,13 @@ class SessionInformation(NamedTuple):
     This field is None until the appropriate initialize_session(s) method is called.
     """
 
+    annotations: dict[str, str] = {}
+    """Annotations to attach to the session.
+
+    This field is optional and can be used to store any additional metadata
+    related to the session.
+    """
+
     def _check_runtime_type(self, session_type: type) -> None:
         if not isinstance(self.session, session_type):
             raise TypeError(
@@ -162,6 +169,7 @@ class SessionInformation(NamedTuple):
             instrument_type_id=other.instrument_type_id,
             session_exists=other.session_exists,
             channel_mappings=[ChannelMapping._from_grpc_v1(m) for m in other.channel_mappings],
+            annotations=dict(other.annotations),
         )
 
     def _to_grpc_v1(
@@ -174,6 +182,7 @@ class SessionInformation(NamedTuple):
             instrument_type_id=self.instrument_type_id,
             session_exists=self.session_exists,
             channel_mappings=[m._to_grpc_v1() for m in self.channel_mappings],
+            annotations=self.annotations,
         )
 
 
@@ -253,6 +262,13 @@ class MultiplexerSessionInformation(NamedTuple):
     This field is None until the appropriate initialize_multiplexer_session(s) method is called.
     """
 
+    annotations: dict[str, str] = {}
+    """Annotations to attach to the session.
+
+    This field is optional and can be used to store any additional metadata
+    related to the session.
+    """
+
     def _check_runtime_type(self, multiplexer_session_type: type) -> None:
         if not isinstance(self.session, multiplexer_session_type):
             raise TypeError(
@@ -274,6 +290,7 @@ class MultiplexerSessionInformation(NamedTuple):
             resource_name=other.resource_name,
             multiplexer_type_id=other.multiplexer_type_id,
             session_exists=other.session_exists,
+            annotations=dict(other.annotations),
         )
 
     def _to_grpc_v1(self) -> session_management_service_pb2.MultiplexerSessionInformation:
@@ -282,6 +299,7 @@ class MultiplexerSessionInformation(NamedTuple):
             resource_name=self.resource_name,
             multiplexer_type_id=self.multiplexer_type_id,
             session_exists=self.session_exists,
+            annotations=self.annotations,
         )
 
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

- This Pull Request implements support for the [Feature 3079033](https://dev.azure.com/ni/DevCentral/_workitems/edit/3079033): View which machine has registered/reserved a session in the Manage Instrument Session UI.
- To enable this, we populate the newly introduced `annotations` parameter with client machine details during session reservation and registration. The following request types now include these annotations:
  - `ReserveSessionRequest`
  - `RegisterSessionsRequest`
  - `RegisterMultiplexerSessionsRequest`
  - `ReserveAllRegisteredSessionsRequest`

- A new `_helpers.py` file has been added to encapsulate helper methods for retrieving client machine details. These methods use:
  - **Win32 APIs** to fetch hostname and username
  - **`socket.gethostbyname`** to retrieve the IP address


### Why should this Pull Request be merged?

This change ensures that client machine details are sent via the Python SDK whenever a session is reserved or registered. These details are then displayed in InstrumentStudio's Manage Instrument Session UI, improving traceability and user context.

### What testing has been done?

Manually verified the behavior using the [Argo Installer](https://emerson.sharepoint.com/:f:/r/sites/TM-ModernLabReferenceArchitecture/Shared%20Documents/Installers/25.8.0.313-0+d313?csf=1&web=1&e=rsIvqI).

### Additional references:
- [Pull Request 1032419](https://dev.azure.com/ni/DevCentral/_git/ASW/pullrequest/1032419): HLD to Display Client Details and Enable Ownership-Based Session Control in Manage Session UI
- [Pull Request 1048178](https://dev.azure.com/ni/DevCentral/_git/ASW/pullrequest/1048178): feat: Add Annotations in SessionManagementClient and extend support to .NET Framework
- https://github.com/ni/measurement-plugin-labview/pull/672
