### PR TITLE
add: Add annotation key constants for session management client

### DIFF
--- a/packages/ni.measurementlink.sessionmanagement.v1.proto/docs/namespace.rst
+++ b/packages/ni.measurementlink.sessionmanagement.v1.proto/docs/namespace.rst
@@ -15,5 +15,6 @@ Submodules
 .. toctree::
    :maxdepth: 1
 
+   /autoapi/ni/measurementlink/sessionmanagement/v1/annotations/index
    /autoapi/ni/measurementlink/sessionmanagement/v1/session_management_service_pb2/index
    /autoapi/ni/measurementlink/sessionmanagement/v1/session_management_service_pb2_grpc/index

--- a/packages/ni.measurementlink.sessionmanagement.v1.proto/src/ni/measurementlink/sessionmanagement/v1/annotations/__init__.py
+++ b/packages/ni.measurementlink.sessionmanagement.v1.proto/src/ni/measurementlink/sessionmanagement/v1/annotations/__init__.py
@@ -1,0 +1,19 @@
+"""Constants for session client details annotations."""
+
+RESERVED_HOSTNAME = "ni/reserved.hostname"
+"""Key for an annotation indicating the hostname that reserved the session."""
+
+RESERVED_USERNAME = "ni/reserved.username"
+"""Key for an annotation indicating the user name that reserved the session."""
+
+RESERVED_IPADDRESS = "ni/reserved.ipaddress"
+"""Key for an annotation indicating the IP address that reserved the session."""
+
+REGISTERED_HOSTNAME = "ni/registered.hostname"
+"""Key for an annotation indicating the hostname that registered the session."""
+
+REGISTERED_USERNAME = "ni/registered.username"
+"""Key for an annotation indicating the user name that registered the session."""
+
+REGISTERED_IPADDRESS = "ni/registered.ipaddress"
+"""Key for an annotation indicating the IP address that registered the session."""


### PR DESCRIPTION
### What does this Pull Request accomplish?

This Pull Request adds annotation key constants needed for the session management client to store client machine details as part of this [Feature 3079033](https://dev.azure.com/ni/DevCentral/_workitems/edit/3079033): View which machine has registered/reserved a session in the Manage Instrument Session UI.

### Why should this Pull Request be merged?

As discussed [here](https://github.com/ni/ni-apis-python/pull/129#discussion_r2334279265), placing these constants in the .proto package allows the client to use them directly.

### What testing has been done?
- `ni.measurementlink.sessionmanagement.v1.proto`
  - mypy and styleguide.