### PR TITLE
Enable process_docstring for ni.measurementlink.proto

### DIFF
--- a/packages/ni.measurementlink.proto/docs/conf.py
+++ b/packages/ni.measurementlink.proto/docs/conf.py
@@ -62,7 +62,7 @@ def process_docstring(app, what, name, obj, options, lines):
 
 def setup(sphinx):
     """Sphinx setup callback."""
-    pass
+    sphinx.connect("autodoc-process-docstring", process_docstring)
 
 
 # List of patterns, relative to source directory, that match files and


### PR DESCRIPTION
### What does this Pull Request accomplish?

Connects the `autodoc-process-docstring` event to the `process_docstring` method. This will filter out any docstrings like

`@generated by mypy-protobuf`

### Why should this Pull Request be merged?

Removes the auto-generated docstring from readthedocs since it's not useful.

Finishes implementation for [AB#3233030](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3233030)

### What testing has been done?

PR checks and RTD build should be sufficient.
