### PR TITLE
Update ni.measurements.metadata.v1.proto dependency

### DIFF
--- a/packages/ni.measurements.data.v1.proto/poetry.lock
+++ b/packages/ni.measurements.data.v1.proto/poetry.lock
@@ -1952,4 +1952,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "873d489e3f7b5acb647e114c72239703b569b3f4717858cc95b17e185a86acc1"
+content-hash = "07213a65476b55ab7aab19ca865f9f5d5a9078ad0b64ea47096d477feed778c3"

--- a/packages/ni.measurements.data.v1.proto/pyproject.toml
+++ b/packages/ni.measurements.data.v1.proto/pyproject.toml
@@ -39,7 +39,7 @@ requires-poetry = '>=2.1,<3.0'
 [tool.poetry.dependencies]
 protobuf = {version=">=4.21"}
 ni-datamonikers-v1-proto = { version = ">=0.1.0.dev0", allow-prereleases = true }
-ni-measurements-metadata-v1-proto = { version = ">=0.1.0.dev0", allow-prereleases = true }
+ni-measurements-metadata-v1-proto = { version = ">=0.1.0.dev1", allow-prereleases = true }
 ni-protobuf-types = { version = ">=0.1.0.dev3", allow-prereleases = true }
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update dependency on metadata.proto to 0.1.0-dev1 in order to properly uptake the rename changes.

### Why should this Pull Request be merged?

To ensure we are depending on a version of metadata.proto that has the renames implemented.

### What testing has been done?

mypy, pyright, styleguide
