### PR TITLE
ni-grpc-extensions: Stop installing traceloggingdynamic on Linux

### DIFF
--- a/.github/actions/run_and_upload_unit_tests/action.yml
+++ b/.github/actions/run_and_upload_unit_tests/action.yml
@@ -15,7 +15,7 @@ runs:
       run: echo "osVersion=$ImageOS" >> "$GITHUB_ENV"
       shell: bash
     - name: Cache ${{ inputs.package-name }} virtualenv
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ github.workspace }}/${{ inputs.package-basepath }}/${{ inputs.package-name }}/.venv
         key: ${{ inputs.package-name }}-${{ runner.os }}-py${{ env.pythonVersion }}-${{ hashFiles(format('{0}/{1}/poetry.lock', inputs.package-basepath, inputs.package-name)) }}

--- a/.github/workflows/check_analyzers.yml
+++ b/.github/workflows/check_analyzers.yml
@@ -37,14 +37,14 @@ jobs:
         with:
           submodules: true
       - name: Set up Python
-        uses: ni/python-actions/setup-python@1b90235a5fcc5e52f0e39e8d2ae9e91d3e3903f2 # v0.6.0
+        uses: ni/python-actions/setup-python@f42e2f27a585f5d47efcab79b608ec0ec97191c9 # v0.6.1
         id: setup-python
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up Poetry
-        uses: ni/python-actions/setup-poetry@1b90235a5fcc5e52f0e39e8d2ae9e91d3e3903f2 # v0.6.0
+        uses: ni/python-actions/setup-poetry@f42e2f27a585f5d47efcab79b608ec0ec97191c9 # v0.6.1
       - name: Analyze Python Project
-        uses: ni/python-actions/analyze-project@1b90235a5fcc5e52f0e39e8d2ae9e91d3e3903f2 # v0.6.0
+        uses: ni/python-actions/analyze-project@f42e2f27a585f5d47efcab79b608ec0ec97191c9 # v0.6.1
         with:
           project-directory: ${{ github.workspace }}/${{ inputs.package-basepath }}/${{ inputs.package-name }}
           extras: ${{ inputs.install-extras }}

--- a/.github/workflows/check_codegen.yml
+++ b/.github/workflows/check_codegen.yml
@@ -49,14 +49,14 @@ jobs:
         with:
           submodules: true
       - name: Set up Python
-        uses: ni/python-actions/setup-python@1b90235a5fcc5e52f0e39e8d2ae9e91d3e3903f2 # v0.6.0
+        uses: ni/python-actions/setup-python@f42e2f27a585f5d47efcab79b608ec0ec97191c9 # v0.6.1
         id: setup-python
       - name: Set up Poetry
-        uses: ni/python-actions/setup-poetry@1b90235a5fcc5e52f0e39e8d2ae9e91d3e3903f2 # v0.6.0
+        uses: ni/python-actions/setup-poetry@f42e2f27a585f5d47efcab79b608ec0ec97191c9 # v0.6.1
       - name: Check for lock changes
         run: poetry check --lock
       - name: Cache virtualenv
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ github.workspace }}/tools/grpc_generator/.venv
           key: grpc_generator-only-main-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('tools/grpc_generator/poetry.lock') }}

--- a/.github/workflows/check_docs.yml
+++ b/.github/workflows/check_docs.yml
@@ -26,14 +26,14 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Set up Python
-        uses: ni/python-actions/setup-python@1b90235a5fcc5e52f0e39e8d2ae9e91d3e3903f2 # v0.6.0
+        uses: ni/python-actions/setup-python@f42e2f27a585f5d47efcab79b608ec0ec97191c9 # v0.6.1
         id: setup-python
       - name: Set up Poetry
-        uses: ni/python-actions/setup-poetry@1b90235a5fcc5e52f0e39e8d2ae9e91d3e3903f2 # v0.6.0
+        uses: ni/python-actions/setup-poetry@f42e2f27a585f5d47efcab79b608ec0ec97191c9 # v0.6.1
       - name: Check for lock changes
         run: poetry check --lock
       - name: Cache virtualenv (with docs)
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ github.workspace }}/${{ inputs.package-basepath }}/${{ inputs.package-name }}/.venv
           key: ${{ inputs.package-name }}-with-docs-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles(format('{0}/{1}/poetry.lock', inputs.package-basepath, inputs.package-name)) }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,12 +100,12 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Set up Python
-        uses: ni/python-actions/setup-python@1b90235a5fcc5e52f0e39e8d2ae9e91d3e3903f2 # v0.6.0
+        uses: ni/python-actions/setup-python@f42e2f27a585f5d47efcab79b608ec0ec97191c9 # v0.6.1
       - name: Set up Poetry
-        uses: ni/python-actions/setup-poetry@1b90235a5fcc5e52f0e39e8d2ae9e91d3e3903f2 # v0.6.0
+        uses: ni/python-actions/setup-poetry@f42e2f27a585f5d47efcab79b608ec0ec97191c9 # v0.6.1
       - name: Check project version
         if: github.event_name == 'release'
-        uses: ni/python-actions/check-project-version@1b90235a5fcc5e52f0e39e8d2ae9e91d3e3903f2 # v0.6.0
+        uses: ni/python-actions/check-project-version@f42e2f27a585f5d47efcab79b608ec0ec97191c9 # v0.6.1
         with:
           project-directory: ./${{ needs.get_package_info.outputs.package-basepath }}/${{ needs.get_publish_info.outputs.package-name }}
           expected-version: ${{ needs.get_publish_info.outputs.package-version }}
@@ -152,11 +152,11 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Set up Python
-        uses: ni/python-actions/setup-python@1b90235a5fcc5e52f0e39e8d2ae9e91d3e3903f2 # v0.6.0
+        uses: ni/python-actions/setup-python@f42e2f27a585f5d47efcab79b608ec0ec97191c9 # v0.6.1
       - name: Set up Poetry
-        uses: ni/python-actions/setup-poetry@1b90235a5fcc5e52f0e39e8d2ae9e91d3e3903f2 # v0.6.0
+        uses: ni/python-actions/setup-poetry@f42e2f27a585f5d47efcab79b608ec0ec97191c9 # v0.6.1
       - name: Update project version
-        uses: ni/python-actions/update-project-version@1b90235a5fcc5e52f0e39e8d2ae9e91d3e3903f2 # v0.6.0
+        uses: ni/python-actions/update-project-version@f42e2f27a585f5d47efcab79b608ec0ec97191c9 # v0.6.1
         with:
           project-directory: ./${{ needs.get_package_info.outputs.package-basepath }}/${{ needs.get_publish_info.outputs.package-name }}
           branch-prefix: users/build/${{ needs.get_publish_info.outputs.package-name }}-

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -41,12 +41,12 @@ jobs:
         with:
           submodules: true
       - name: Set up Python
-        uses: ni/python-actions/setup-python@1b90235a5fcc5e52f0e39e8d2ae9e91d3e3903f2 # v0.6.0
+        uses: ni/python-actions/setup-python@f42e2f27a585f5d47efcab79b608ec0ec97191c9 # v0.6.1
         id: setup-python
         with:
           python-version: ${{ inputs.python-version }}
       - name: Set up Poetry
-        uses: ni/python-actions/setup-poetry@1b90235a5fcc5e52f0e39e8d2ae9e91d3e3903f2 # v0.6.0
+        uses: ni/python-actions/setup-poetry@f42e2f27a585f5d47efcab79b608ec0ec97191c9 # v0.6.1
       - name: Run and upload unit tests for ${{ inputs.package-name }}
         uses: ./.github/actions/run_and_upload_unit_tests
         with:

--- a/packages/ni-grpc-extensions/poetry.lock
+++ b/packages/ni-grpc-extensions/poetry.lock
@@ -885,7 +885,7 @@ name = "ni-measurementlink-discovery-v1-proto"
 version = "0.1.0-dev2"
 description = "Protobuf data types for NI discovery gRPC APIs"
 optional = false
-python-versions = "^3.9"
+python-versions = ">=3.9,<4.0"
 groups = ["test"]
 files = []
 develop = false
@@ -1770,8 +1770,8 @@ version = "1.0.1"
 description = "Generates Event Tracing for Windows events using TraceLogging"
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "dev"]
-markers = "sys_platform == \"win32\" or sys_platform == \"linux\""
+groups = ["main"]
+markers = "sys_platform == \"win32\""
 files = [
     {file = "traceloggingdynamic-1.0.1-py3-none-any.whl", hash = "sha256:0e19da491a8960725b3622366487ae35f49d8f595bb2e4e5ce1795eb5928db7c"},
     {file = "traceloggingdynamic-1.0.1.tar.gz", hash = "sha256:d9dd4b291dd04c15e34181eed06f73fdf4ffa7b1f895b78217163def48ab1a52"},
@@ -1844,4 +1844,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "a0204212545e044234226f5afd7c12ce8b8c5738cf53365034ac0005b0cde9b2"
+content-hash = "4a0aee0cafb73e976d340ee2ac1a05889f7630f36a4d5677d9405d1f90b59516"

--- a/packages/ni-grpc-extensions/pyproject.toml
+++ b/packages/ni-grpc-extensions/pyproject.toml
@@ -43,8 +43,6 @@ traceloggingdynamic = { version = ">=1.0", platform = "win32" }
 
 [tool.poetry.group.dev.dependencies]
 types-grpcio = ">=1.0"
-# Install traceloggingdynamic on Linux for type checking.
-traceloggingdynamic = { version = ">=1.0", platform = "linux" }
 
 [tool.poetry.group.lint.dependencies]
 bandit = { version = ">=1.7", extras = ["toml"] }

--- a/packages/ni-grpc-extensions/src/ni_grpc_extensions/_tracelogging.py
+++ b/packages/ni-grpc-extensions/src/ni_grpc_extensions/_tracelogging.py
@@ -14,6 +14,7 @@ if sys.platform == "win32":
     except ImportError:
         _event_provider = None
 else:
+    traceloggingdynamic = None
     _event_provider = None
 
 _LEVEL_LOG_ALWAYS = 0

--- a/packages/ni-grpc-extensions/src/ni_grpc_extensions/_tracelogging.py
+++ b/packages/ni-grpc-extensions/src/ni_grpc_extensions/_tracelogging.py
@@ -6,15 +6,19 @@ import uuid
 from typing import Any
 
 if sys.platform == "win32":
-    from traceloggingdynamic import EventBuilder, Provider
+    import traceloggingdynamic
 
-    _event_provider = Provider(b"NI-Grpc-Python")
+    _event_provider = traceloggingdynamic.Provider(b"NI-Grpc-Python")
+
+    def _create_event_builder() -> traceloggingdynamic.EventBuilder:
+        return traceloggingdynamic.EventBuilder()
+
 else:
-
-    def EventBuilder() -> Any:  # noqa: D103,N802
-        return None
-
     _event_provider = None
+
+    def _create_event_builder() -> Any:
+        raise RuntimeError(f"Unsupported platform: {sys.platform}")
+
 
 _LEVEL_LOG_ALWAYS = 0
 _LEVEL_CRITICAL = 1
@@ -83,7 +87,7 @@ def is_enabled() -> bool:
 def log_grpc_client_call_start(method_name: str) -> uuid.UUID | None:
     """Log when starting a gRPC client call."""
     if _event_provider and _event_provider.is_enabled(level=_LEVEL_INFO, keyword=_KEYWORD_GRPC):
-        eb = EventBuilder()
+        eb = _create_event_builder()
         eb.reset(
             b"GrpcClientCall",
             level=_LEVEL_INFO,
@@ -103,7 +107,7 @@ def log_grpc_client_call_start(method_name: str) -> uuid.UUID | None:
 def log_grpc_client_call_stop(method_name: str, activity_id: uuid.UUID | None = None) -> None:
     """Log when a gRPC client call has completed."""
     if _event_provider and _event_provider.is_enabled(level=_LEVEL_INFO, keyword=_KEYWORD_GRPC):
-        eb = EventBuilder()
+        eb = _create_event_builder()
         eb.reset(
             b"GrpcClientCall",
             level=_LEVEL_INFO,
@@ -118,7 +122,7 @@ def log_grpc_client_call_stop(method_name: str, activity_id: uuid.UUID | None = 
 def log_grpc_client_call_streaming_request(method_name: str) -> None:
     """Log when a gRPC client call is sending a client-streaming request."""
     if _event_provider and _event_provider.is_enabled(level=_LEVEL_INFO, keyword=_KEYWORD_GRPC):
-        eb = EventBuilder()
+        eb = _create_event_builder()
         eb.reset(
             b"GrpcClientCallStreamingRequest",
             level=_LEVEL_INFO,
@@ -132,7 +136,7 @@ def log_grpc_client_call_streaming_request(method_name: str) -> None:
 def log_grpc_client_call_streaming_response(method_name: str) -> None:
     """Log when a gRPC client call has received a server-streaming response."""
     if _event_provider and _event_provider.is_enabled(level=_LEVEL_INFO, keyword=_KEYWORD_GRPC):
-        eb = EventBuilder()
+        eb = _create_event_builder()
         eb.reset(
             b"GrpcClientCallStreamingResponse",
             level=_LEVEL_INFO,
@@ -146,7 +150,7 @@ def log_grpc_client_call_streaming_response(method_name: str) -> None:
 def log_grpc_server_call_start(method_name: str) -> uuid.UUID | None:
     """Log when starting a gRPC server call."""
     if _event_provider and _event_provider.is_enabled(level=_LEVEL_INFO, keyword=_KEYWORD_GRPC):
-        eb = EventBuilder()
+        eb = _create_event_builder()
         eb.reset(
             b"GrpcServerCall",
             level=_LEVEL_INFO,
@@ -166,7 +170,7 @@ def log_grpc_server_call_start(method_name: str) -> uuid.UUID | None:
 def log_grpc_server_call_stop(method_name: str, activity_id: uuid.UUID | None = None) -> None:
     """Log when a gRPC server call has completed."""
     if _event_provider and _event_provider.is_enabled(level=_LEVEL_INFO, keyword=_KEYWORD_GRPC):
-        eb = EventBuilder()
+        eb = _create_event_builder()
         eb.reset(
             b"GrpcServerCall",
             level=_LEVEL_INFO,
@@ -181,7 +185,7 @@ def log_grpc_server_call_stop(method_name: str, activity_id: uuid.UUID | None = 
 def log_grpc_server_call_streaming_request(method_name: str) -> None:
     """Log when a gRPC server call is sending a server-streaming request."""
     if _event_provider and _event_provider.is_enabled(level=_LEVEL_INFO, keyword=_KEYWORD_GRPC):
-        eb = EventBuilder()
+        eb = _create_event_builder()
         eb.reset(
             b"GrpcServerCallStreamingRequest",
             level=_LEVEL_INFO,
@@ -195,7 +199,7 @@ def log_grpc_server_call_streaming_request(method_name: str) -> None:
 def log_grpc_server_call_streaming_response(method_name: str) -> None:
     """Log when a gRPC server call has received a server-streaming response."""
     if _event_provider and _event_provider.is_enabled(level=_LEVEL_INFO, keyword=_KEYWORD_GRPC):
-        eb = EventBuilder()
+        eb = _create_event_builder()
         eb.reset(
             b"GrpcServerCallStreamingResponse",
             level=_LEVEL_INFO,

--- a/packages/ni-grpc-extensions/src/ni_grpc_extensions/_tracelogging.py
+++ b/packages/ni-grpc-extensions/src/ni_grpc_extensions/_tracelogging.py
@@ -3,18 +3,17 @@ from __future__ import annotations
 import ctypes
 import sys
 import uuid
+from typing import Any
 
 if sys.platform == "win32":
-    try:
-        import traceloggingdynamic
+    from traceloggingdynamic import EventBuilder, Provider
 
-        _event_provider: traceloggingdynamic.Provider | None = traceloggingdynamic.Provider(
-            b"NI-Grpc-Python"
-        )
-    except ImportError:
-        _event_provider = None
+    _event_provider = Provider(b"NI-Grpc-Python")
 else:
-    traceloggingdynamic = None
+
+    def EventBuilder() -> Any:  # noqa: D103,N802
+        return None
+
     _event_provider = None
 
 _LEVEL_LOG_ALWAYS = 0
@@ -84,7 +83,7 @@ def is_enabled() -> bool:
 def log_grpc_client_call_start(method_name: str) -> uuid.UUID | None:
     """Log when starting a gRPC client call."""
     if _event_provider and _event_provider.is_enabled(level=_LEVEL_INFO, keyword=_KEYWORD_GRPC):
-        eb = traceloggingdynamic.EventBuilder()  # pyright: ignore[reportPossiblyUnboundVariable]
+        eb = EventBuilder()
         eb.reset(
             b"GrpcClientCall",
             level=_LEVEL_INFO,
@@ -104,7 +103,7 @@ def log_grpc_client_call_start(method_name: str) -> uuid.UUID | None:
 def log_grpc_client_call_stop(method_name: str, activity_id: uuid.UUID | None = None) -> None:
     """Log when a gRPC client call has completed."""
     if _event_provider and _event_provider.is_enabled(level=_LEVEL_INFO, keyword=_KEYWORD_GRPC):
-        eb = traceloggingdynamic.EventBuilder()  # pyright: ignore[reportPossiblyUnboundVariable]
+        eb = EventBuilder()
         eb.reset(
             b"GrpcClientCall",
             level=_LEVEL_INFO,
@@ -119,7 +118,7 @@ def log_grpc_client_call_stop(method_name: str, activity_id: uuid.UUID | None = 
 def log_grpc_client_call_streaming_request(method_name: str) -> None:
     """Log when a gRPC client call is sending a client-streaming request."""
     if _event_provider and _event_provider.is_enabled(level=_LEVEL_INFO, keyword=_KEYWORD_GRPC):
-        eb = traceloggingdynamic.EventBuilder()  # pyright: ignore[reportPossiblyUnboundVariable]
+        eb = EventBuilder()
         eb.reset(
             b"GrpcClientCallStreamingRequest",
             level=_LEVEL_INFO,
@@ -133,7 +132,7 @@ def log_grpc_client_call_streaming_request(method_name: str) -> None:
 def log_grpc_client_call_streaming_response(method_name: str) -> None:
     """Log when a gRPC client call has received a server-streaming response."""
     if _event_provider and _event_provider.is_enabled(level=_LEVEL_INFO, keyword=_KEYWORD_GRPC):
-        eb = traceloggingdynamic.EventBuilder()  # pyright: ignore[reportPossiblyUnboundVariable]
+        eb = EventBuilder()
         eb.reset(
             b"GrpcClientCallStreamingResponse",
             level=_LEVEL_INFO,
@@ -147,7 +146,7 @@ def log_grpc_client_call_streaming_response(method_name: str) -> None:
 def log_grpc_server_call_start(method_name: str) -> uuid.UUID | None:
     """Log when starting a gRPC server call."""
     if _event_provider and _event_provider.is_enabled(level=_LEVEL_INFO, keyword=_KEYWORD_GRPC):
-        eb = traceloggingdynamic.EventBuilder()  # pyright: ignore[reportPossiblyUnboundVariable]
+        eb = EventBuilder()
         eb.reset(
             b"GrpcServerCall",
             level=_LEVEL_INFO,
@@ -167,7 +166,7 @@ def log_grpc_server_call_start(method_name: str) -> uuid.UUID | None:
 def log_grpc_server_call_stop(method_name: str, activity_id: uuid.UUID | None = None) -> None:
     """Log when a gRPC server call has completed."""
     if _event_provider and _event_provider.is_enabled(level=_LEVEL_INFO, keyword=_KEYWORD_GRPC):
-        eb = traceloggingdynamic.EventBuilder()  # pyright: ignore[reportPossiblyUnboundVariable]
+        eb = EventBuilder()
         eb.reset(
             b"GrpcServerCall",
             level=_LEVEL_INFO,
@@ -182,7 +181,7 @@ def log_grpc_server_call_stop(method_name: str, activity_id: uuid.UUID | None = 
 def log_grpc_server_call_streaming_request(method_name: str) -> None:
     """Log when a gRPC server call is sending a server-streaming request."""
     if _event_provider and _event_provider.is_enabled(level=_LEVEL_INFO, keyword=_KEYWORD_GRPC):
-        eb = traceloggingdynamic.EventBuilder()  # pyright: ignore[reportPossiblyUnboundVariable]
+        eb = EventBuilder()
         eb.reset(
             b"GrpcServerCallStreamingRequest",
             level=_LEVEL_INFO,
@@ -196,7 +195,7 @@ def log_grpc_server_call_streaming_request(method_name: str) -> None:
 def log_grpc_server_call_streaming_response(method_name: str) -> None:
     """Log when a gRPC server call has received a server-streaming response."""
     if _event_provider and _event_provider.is_enabled(level=_LEVEL_INFO, keyword=_KEYWORD_GRPC):
-        eb = traceloggingdynamic.EventBuilder()  # pyright: ignore[reportPossiblyUnboundVariable]
+        eb = EventBuilder()
         eb.reset(
             b"GrpcServerCallStreamingResponse",
             level=_LEVEL_INFO,

--- a/packages/ni-grpc-extensions/src/ni_grpc_extensions/_tracelogging.py
+++ b/packages/ni-grpc-extensions/src/ni_grpc_extensions/_tracelogging.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import ctypes
 import sys
 import uuid
-from typing import TYPE_CHECKING
 
 if sys.platform == "win32":
     try:
@@ -15,9 +14,6 @@ if sys.platform == "win32":
     except ImportError:
         _event_provider = None
 else:
-    if TYPE_CHECKING:
-        import traceloggingdynamic
-
     _event_provider = None
 
 _LEVEL_LOG_ALWAYS = 0


### PR DESCRIPTION
### What does this Pull Request accomplish?

ni-grpc-extensions:
- Remove traceloggingdynamic on Linux from dev dependencies.
- Remove try/except ImportError from _tracelogging.py
- Wrap EventBuilder construction in a helper function and redefine it to throw an unsupported platform exception in non-Windows case.

### Why should this Pull Request be merged?

Now that the PR workflow runs mypy and Pyright separately on Linux, Mac, and Windows, it no longer makes sense to install traceloggingdynamic on Linux.

Since the last time we visited this issue, we have learned that the "install it on all platforms" approach doesn't work for some modules, like pywin32.

### What testing has been done?

PR build