### PR TITLE
Flatten the workflow hierarchy for run_unit_tests

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -1,5 +1,4 @@
 name: Test package
-
 on:
   workflow_call:
     inputs:
@@ -18,21 +17,35 @@ on:
 
 jobs:
   get_package_info:
-    name: Get package info for ${{ inputs.package-name }}
+    name: Get package info - ${{ inputs.package-name }}
     uses: ./.github/workflows/get_package_info.yml
     with:
       package-name: ${{ inputs.package-name }}
   run_unit_tests:
     if: ${{ needs.get_package_info.outputs.should-run-tests == 'true' }}
     strategy:
+      # Fail-fast skews the pass/fail ratio and seems to make pytest produce
+      # incomplete JUnit XML results.
+      fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
         python-version: [3.9, '3.10', 3.11, 3.12, 3.13]
-    name: Run unit tests
+    name: Run unit tests - ${{ inputs.package-name }} (${{ matrix.python-version }} - ${{ matrix.os }})
     needs: get_package_info
-    uses: ./.github/workflows/run_unit_tests.yml
-    with:
-      package-name: ${{ inputs.package-name }}
-      package-basepath: ${{ needs.get_package_info.outputs.package-basepath }}
-      python-version: ${{ matrix.python-version }}
-      os: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          submodules: true
+      - name: Set up Python
+        uses: ni/python-actions/setup-python@f42e2f27a585f5d47efcab79b608ec0ec97191c9 # v0.6.1
+        id: setup-python
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set up Poetry
+        uses: ni/python-actions/setup-poetry@f42e2f27a585f5d47efcab79b608ec0ec97191c9 # v0.6.1
+      - uses: ./.github/actions/run_and_upload_unit_tests
+        with:
+          package-name: ${{ inputs.package-name }}
+          package-basepath: ${{ needs.get_package_info.outputs.package-basepath }}


### PR DESCRIPTION
### What does this Pull Request accomplish?

Eliminate one layer of workflow (run_unit_tests.yml) and put a call to run_and_upload_unit_tests composite action directly from test_package.yml.

### Why should this Pull Request be merged?

We were getting four levels of workflow hierachy running unit tests. This is kind of unnecessary and hard to follow the flow of the CI.

### What testing has been done?

Current PR checks and unit tests still run and pass.
