### PR TITLE
Bump packages to 1.0.0 for stable release

### DIFF
--- a/packages/ni-grpc-extensions/pyproject.toml
+++ b/packages/ni-grpc-extensions/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ni-grpc-extensions"
-version = "0.1.0-dev2"
+version = "1.0.0"
 license = "MIT"
 description = "gRPC Extensions"
 authors = [{name = "NI", email = "opensource@ni.com"}]
@@ -11,7 +11,7 @@ maintainers = [
 readme = "README.md"
 keywords = ["grpc", "extensions", "channel_pool"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Manufacturing",
   "Intended Audience :: Science/Research",

--- a/packages/ni.grpcdevice.v1.proto/pyproject.toml
+++ b/packages/ni.grpcdevice.v1.proto/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ni.grpcdevice.v1.proto"
-version = "0.1.0-dev3"
+version = "1.0.0"
 license = "MIT"
 description = "Protobuf generated code for the nidevice_grpc gRPC API"
 authors = [{name = "NI", email = "opensource@ni.com"}]
@@ -11,7 +11,7 @@ maintainers = [
 readme = "README.md"
 keywords = ["ni-apis", "grpc-device", "ni_grpc_device_server"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Manufacturing",
   "Intended Audience :: Science/Research",

--- a/packages/ni.measurementlink.discovery.v1.client/pyproject.toml
+++ b/packages/ni.measurementlink.discovery.v1.client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ni.measurementlink.discovery.v1.client"
-version = "0.1.0-dev1"
+version = "1.0.0"
 license = "MIT"
 description = "gRPC Client for NI Discovery Service"
 authors = [{name = "NI", email = "opensource@ni.com"}]
@@ -11,7 +11,7 @@ maintainers = [
 readme = "README.md"
 keywords = ["discovery", "client"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Manufacturing",
   "Intended Audience :: Science/Research",

--- a/packages/ni.measurementlink.discovery.v1.proto/pyproject.toml
+++ b/packages/ni.measurementlink.discovery.v1.proto/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ni.measurementlink.discovery.v1.proto"
-version = "0.1.0-dev2"
+version = "1.0.0"
 license = "MIT"
 description = "Protobuf data types for NI discovery gRPC APIs"
 authors = [{name = "NI", email = "opensource@ni.com"}]
@@ -11,7 +11,7 @@ maintainers = [
 readme = "README.md"
 keywords = ["ni-apis", "discovery"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Manufacturing",
   "Intended Audience :: Science/Research",

--- a/packages/ni.measurementlink.measurement.v1.proto/pyproject.toml
+++ b/packages/ni.measurementlink.measurement.v1.proto/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ni.measurementlink.measurement.v1.proto"
-version = "0.1.0-dev1"
+version = "1.0.0"
 license = "MIT"
 description = "Protobuf data types for NI measurement gRPC APIs"
 authors = [{name = "NI", email = "opensource@ni.com"}]
@@ -11,7 +11,7 @@ maintainers = [
 readme = "README.md"
 keywords = ["ni-apis", "measurement"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Manufacturing",
   "Intended Audience :: Science/Research",

--- a/packages/ni.measurementlink.measurement.v2.proto/pyproject.toml
+++ b/packages/ni.measurementlink.measurement.v2.proto/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ni.measurementlink.measurement.v2.proto"
-version = "0.1.0-dev1"
+version = "1.0.0"
 license = "MIT"
 description = "Protobuf data types for NI measurement gRPC APIs"
 authors = [{name = "NI", email = "opensource@ni.com"}]
@@ -11,7 +11,7 @@ maintainers = [
 readme = "README.md"
 keywords = ["ni-apis", "measurement"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Manufacturing",
   "Intended Audience :: Science/Research",

--- a/packages/ni.measurementlink.pinmap.v1.client/pyproject.toml
+++ b/packages/ni.measurementlink.pinmap.v1.client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ni.measurementlink.pinmap.v1.client"
-version = "0.1.0-dev1"
+version = "1.0.0"
 license = "MIT"
 description = "gRPC Client for NI Pin Map Service"
 authors = [{name = "NI", email = "opensource@ni.com"}]
@@ -11,7 +11,7 @@ maintainers = [
 readme = "README.md"
 keywords = ["pinmap", "client"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Manufacturing",
   "Intended Audience :: Science/Research",

--- a/packages/ni.measurementlink.pinmap.v1.proto/pyproject.toml
+++ b/packages/ni.measurementlink.pinmap.v1.proto/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ni.measurementlink.pinmap.v1.proto"
-version = "0.1.0-dev1"
+version = "1.0.0"
 license = "MIT"
 description = "Protobuf data types for NI pinmap gRPC APIs"
 authors = [{name = "NI", email = "opensource@ni.com"}]
@@ -11,7 +11,7 @@ maintainers = [
 readme = "README.md"
 keywords = ["ni-apis", "pinmap"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Manufacturing",
   "Intended Audience :: Science/Research",

--- a/packages/ni.measurementlink.proto/pyproject.toml
+++ b/packages/ni.measurementlink.proto/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ni.measurementlink.proto"
-version = "0.1.0-dev2"
+version = "1.0.0"
 license = "MIT"
 description = "Protobuf data types for NI gRPC APIs"
 authors = [{name = "NI", email = "opensource@ni.com"}]
@@ -11,7 +11,7 @@ maintainers = [
 readme = "README.md"
 keywords = ["ni-apis", "discovery"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Manufacturing",
   "Intended Audience :: Science/Research",

--- a/packages/ni.measurementlink.sessionmanagement.v1.client/pyproject.toml
+++ b/packages/ni.measurementlink.sessionmanagement.v1.client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ni.measurementlink.sessionmanagement.v1.client"
-version = "0.1.0-dev3"
+version = "1.0.0"
 license = "MIT"
 description = "Client gRPC APIs for the session management service"
 authors = [{name = "NI", email = "opensource@ni.com"}]
@@ -11,7 +11,7 @@ maintainers = [
 readme = "README.md"
 keywords = ["ni-apis", "sessionmanagement"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Manufacturing",
   "Intended Audience :: Science/Research",

--- a/packages/ni.measurementlink.sessionmanagement.v1.proto/pyproject.toml
+++ b/packages/ni.measurementlink.sessionmanagement.v1.proto/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ni.measurementlink.sessionmanagement.v1.proto"
-version = "0.1.0-dev3"
+version = "1.0.0"
 license = "MIT"
 description = "Protobuf data types for NI session management gRPC APIs"
 authors = [{name = "NI", email = "opensource@ni.com"}]
@@ -11,7 +11,7 @@ maintainers = [
 readme = "README.md"
 keywords = ["ni-apis", "discovery"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Manufacturing",
   "Intended Audience :: Science/Research",

--- a/packages/ni.protobuf.types/pyproject.toml
+++ b/packages/ni.protobuf.types/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ni.protobuf.types"
-version = "0.1.0-dev5"
+version = "1.0.0"
 license = "MIT"
 description = "Protobuf data types for NI gRPC APIs"
 authors = [{name = "NI", email = "opensource@ni.com"}]
@@ -11,7 +11,7 @@ maintainers = [
 readme = "README.md"
 keywords = ["ni-apis", "protobuf"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Manufacturing",
   "Intended Audience :: Science/Research",


### PR DESCRIPTION
### What does this Pull Request accomplish?

Bumps these packages to 1.0.0
* ni-grpc-extensions
* ni.grpcdevice.v1.proto
* ni.measurementlink.discovery.v1.client
* ni.measurementlink.discovery.v1.proto
* ni.measurementlink.measurement.v1.proto
* ni.measurementlink.measurement.v2.proto
* ni.measurementlink.pinmap.v1.client
* ni.measurementlink.pinmap.v1.proto
* ni.measurementlink.proto
* ni.measurementlink.sessionmanagement.v1.client
* ni.measurementlink.sessionmanagement.v1.proto
* ni.protobuf.types

### Why should this Pull Request be merged?

We need these packages to be released and not prerelease versions so we can release another dependent package. These are packages whose code has been around for a while, so we're ready to release them.

### What testing has been done?

Version bump only. No code changes.
