### PR TITLE
Bump data.client version to 1.1.0 due to Read changes

### DIFF
--- a/packages/ni.measurements.data.v1.client/poetry.lock
+++ b/packages/ni.measurements.data.v1.client/poetry.lock
@@ -1107,7 +1107,7 @@ protobuf = ">=4.21"
 
 [[package]]
 name = "ni-measurements-data-v1-proto"
-version = "1.0.1.dev0"
+version = "1.1.0.dev1"
 description = "Protobuf data types and service stubs for NI data store gRPC APIs"
 optional = false
 python-versions = ">=3.10,<4.0"
@@ -2342,4 +2342,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "70af5571992c7eb4a3155a8766fc0a0b0974dd2436c247302415c4fb97bba977"
+content-hash = "bdd65601f2df846a78d85cf9750cc72e6fdbd6d5de52f9b4b6224526d30a3703"

--- a/packages/ni.measurements.data.v1.client/pyproject.toml
+++ b/packages/ni.measurements.data.v1.client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ni.measurements.data.v1.client"
-version = "1.0.1.dev0"
+version = "1.1.0.dev0"
 license = "MIT"
 description = "gRPC Client for NI Data Store Service"
 authors = [{name = "NI", email = "opensource@ni.com"}]
@@ -38,7 +38,7 @@ requires-poetry = '>=2.1,<3.0'
 
 [tool.poetry.dependencies]
 ni-measurementlink-discovery-v1-client = { version = ">=1.1.0" }
-ni-measurements-data-v1-proto = { version = ">=1.0.0" }
+ni-measurements-data-v1-proto = { version = ">=1.1.0.dev0", allow-prereleases = true }
 
 [tool.poetry.group.dev.dependencies]
 types-grpcio = ">=1.0"


### PR DESCRIPTION
### What does this Pull Request accomplish?

Bumps the ni.measurement.data.v1.client version to 1.1.0dev0.

Addresses part of [AB#3712177](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3712177)

This PR also updates the .proto dependency to `>=1.1.0.dev0`

### Why should this Pull Request be merged?

This minor version bump is being made to account for the addition of
* ReadMeasurementValue
* ReadConditionValue

### What testing has been done?

PR workflow checks
