### PR TITLE
Downgrade the download-artifact version to match the upload-artifact version

### DIFF
--- a/.github/workflows/report_test_results.yml
+++ b/.github/workflows/report_test_results.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download test results
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@v7
         with:
           path: test_results
           pattern: test_results_*


### PR DESCRIPTION
### What does this Pull Request accomplish?

All PRs in this repo are failing. Copilot tells me it's likely because the `download-artifact` and `upload-artifact` major versions are different. This PR downgrades the `download-artifact` version to `v7` to try and get the workflows passing again.

### Why should this Pull Request be merged?

To unblock PRs in this repo.

### What testing has been done?

PR workflow
