### PR TITLE
Bump Minor Version of ni.protobuf.types

### DIFF
--- a/packages/ni.protobuf.types/pyproject.toml
+++ b/packages/ni.protobuf.types/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ni.protobuf.types"
-version = "1.1.1.dev0"
+version = "1.2.0.dev0"
 license = "MIT"
 description = "Protobuf data types for NI gRPC APIs"
 authors = [{name = "NI", email = "opensource@ni.com"}]


### PR DESCRIPTION
### What does this Pull Request accomplish?

In advance of publishing any pre-release version(s) of `ni.protobuf.types` to PyPI, we are bumping the minor version of the package to reflect the new types and properties on existing types that have been added to this package since the previous release ([1.1.0](https://pypi.org/project/ni.protobuf.types/#history)).

See the relevant `.proto` changes here:

- https://github.com/ni/ni-apis/pull/161
- https://github.com/ni/ni-apis/pull/168

See the relevant `ni-apis-python` updates here:
- https://github.com/ni/ni-apis-python/pull/315
- https://github.com/ni/ni-apis-python/pull/321

### Why should this Pull Request be merged?

The minor version bump reflects the new properties/types that have been added.

### What testing has been done?

PR workflow checks