### PR TITLE
ni.measurements.data.v1.proto: Update ni.protobuf.types dependency

### DIFF
--- a/packages/ni.measurements.data.v1.proto/poetry.lock
+++ b/packages/ni.measurements.data.v1.proto/poetry.lock
@@ -1006,7 +1006,7 @@ url = "../ni.measurements.metadata.v1.proto"
 
 [[package]]
 name = "ni-protobuf-types"
-version = "1.1.1.dev0"
+version = "1.2.0.dev0"
 description = "Protobuf data types for NI gRPC APIs"
 optional = false
 python-versions = ">=3.10,<4.0"
@@ -2157,4 +2157,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "6e9705b9ce9e5664e83fa55f4b370f2d03f1a71dcfa0e74476019407713e09be"
+content-hash = "0de23c7942f7fcc4e15d1937b6245d8cbc7be8e0a8336bdcb6314e9006a4e8e2"

--- a/packages/ni.measurements.data.v1.proto/pyproject.toml
+++ b/packages/ni.measurements.data.v1.proto/pyproject.toml
@@ -41,7 +41,7 @@ requires-poetry = '>=2.1,<3.0'
 protobuf = {version=">=4.21"}
 ni-datamonikers-v1-proto = { version = ">=1.0.0" }
 ni-measurements-metadata-v1-proto = { version = ">=1.0.0" }
-ni-protobuf-types = { version = ">=1.1.0" }
+ni-protobuf-types = { version = ">=1.2.0.dev0", allow-prereleases = true }
 
 [tool.poetry.group.dev.dependencies]
 types-grpcio = ">=1.0"


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR updates `ni.measurements.data.v1.proto` to depend on the `1.2.0.dev0` pre-release version of the `ni.protobuf.types` [package](https://pypi.org/project/ni.protobuf.types/#history).

This package version adds support for types such as `VectorArrayValue` that the `PublishMeasurementBatchRequest` code now [depends on](https://github.com/ni/ni-apis-python/blob/618067ef146c8907239159c62c4c1a6c43ccdba9/packages/ni.measurements.data.v1.proto/src/ni/measurements/data/v1/data_store_service_pb2/__init__.pyi#L505-L506) for successful batch publishing of non-scalar measurement data.

### Why should this Pull Request be merged?

This PR updates the `ni.measurements.data.v1.proto` package to have the needed dependency to enable non-scalar batch publishing.

### What testing has been done?

PR workflow checks.