### PR TITLE
ni.measurements.data.v1.client: Update ni.measurements.data.v1.proto dependency

### DIFF
--- a/packages/ni.measurements.data.v1.client/poetry.lock
+++ b/packages/ni.measurements.data.v1.client/poetry.lock
@@ -1128,7 +1128,7 @@ develop = true
 [package.dependencies]
 ni-datamonikers-v1-proto = ">=1.0.0"
 ni-measurements-metadata-v1-proto = ">=1.0.0"
-ni-protobuf-types = ">=1.1.0"
+ni-protobuf-types = ">=1.2.0.dev0"
 protobuf = ">=4.21"
 
 [package.source]
@@ -1154,7 +1154,7 @@ url = "../ni.measurements.metadata.v1.proto"
 
 [[package]]
 name = "ni-protobuf-types"
-version = "1.1.1.dev0"
+version = "1.2.0.dev0"
 description = "Protobuf data types for NI gRPC APIs"
 optional = false
 python-versions = ">=3.10,<4.0"
@@ -2351,4 +2351,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "19fcd10ccacf58742b946b7cc60dd52bed7029f12d5902bf689da972f7a28f2c"
+content-hash = "cc941cf8f340854be33b163c62fc8510fb94ee0adc8b7df6f183bc28284743e0"

--- a/packages/ni.measurements.data.v1.client/pyproject.toml
+++ b/packages/ni.measurements.data.v1.client/pyproject.toml
@@ -38,7 +38,7 @@ requires-poetry = '>=2.1,<3.0'
 
 [tool.poetry.dependencies]
 ni-measurementlink-discovery-v1-client = { version = ">=1.1.0" }
-ni-measurements-data-v1-proto = { version = ">=1.1.0.dev0", allow-prereleases = true }
+ni-measurements-data-v1-proto = { version = ">=1.1.0.dev1", allow-prereleases = true }
 
 [tool.poetry.group.dev.dependencies]
 types-grpcio = ">=1.0"


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR updates `ni.measurements.data.v1.client` to depend on the `1.1.0.dev1` pre-release version of the `ni.measurements.data.v1.proto` package.

This package version adds support for the publishing of non-scalar data via `PublishMeasurementBatch`.

### Why should this Pull Request be merged?

This PR updates the `ni.measurements.data.v1.client` package to support batch publishing of non-scalar data.

### What testing has been done?

PR workflow checks.