### PR TITLE
DataStoreClient - Update Documentation for Batch Publishing

### DIFF
--- a/packages/ni.measurements.data.v1.client/src/ni/measurements/data/v1/client/_client.py
+++ b/packages/ni.measurements.data.v1.client/src/ni/measurements/data/v1/client/_client.py
@@ -98,7 +98,7 @@ class DataStoreClient(GrpcServiceClientBase[data_store_service_pb2_grpc.DataStor
     def publish_measurement_batch(
         self, request: data_store_service_pb2.PublishMeasurementBatchRequest
     ) -> data_store_service_pb2.PublishMeasurementBatchResponse:
-        """Publish multiple scalar measurements at once for parametric sweeps."""
+        """Publish multiple measurement values at once for parametric sweeps."""
         return self._get_stub().PublishMeasurementBatch(request)
 
     def get_measurement(


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR updates the `DataStoreClient` documentation to reflect that `publish_measurement_batch` is no longer restricted to scalar values. 

### Why should this Pull Request be merged?

This change keeps the documentation in sync with the underlying functionality.

### What testing has been done?

PR workflow checks