### PR TITLE
Update ni.measurements.data.v1.proto version and its ni.protobuf.types dependency

### DIFF
--- a/packages/ni.measurements.data.v1.proto/poetry.lock
+++ b/packages/ni.measurements.data.v1.proto/poetry.lock
@@ -1076,7 +1076,7 @@ url = "../ni.measurements.metadata.v1.proto"
 
 [[package]]
 name = "ni-protobuf-types"
-version = "1.2.0.dev0"
+version = "1.2.0"
 description = "Protobuf data types for NI gRPC APIs"
 optional = false
 python-versions = ">=3.10,<4.0"
@@ -1085,7 +1085,7 @@ files = []
 develop = true
 
 [package.dependencies]
-nitypes = ">=1.1.0dev1"
+nitypes = ">=1.1.0"
 protobuf = ">=4.21"
 
 [package.source]
@@ -1128,14 +1128,14 @@ toml = ">=0.10.1"
 
 [[package]]
 name = "nitypes"
-version = "1.1.0.dev1"
+version = "1.1.0"
 description = "Data types for NI Python APIs"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "nitypes-1.1.0.dev1-py3-none-any.whl", hash = "sha256:d98ad6e3f8b92db76b5c1c584431fa27d3e74cce6e20464e43ee0117b02fe089"},
-    {file = "nitypes-1.1.0.dev1.tar.gz", hash = "sha256:50b23e00cc6960996656c4c9ef0ca71dd267fc5c9ca481077b682c29190aa2d3"},
+    {file = "nitypes-1.1.0-py3-none-any.whl", hash = "sha256:b43ac7027e1cceeca7ceffa58f31ffadd03feeb1788ca5cb8f9d105e73893b14"},
+    {file = "nitypes-1.1.0.tar.gz", hash = "sha256:f273b5131ef0d5b848c37a0a63452626caf5c2938f7744c324f7991b76fa0b60"},
 ]
 
 [package.dependencies]
@@ -2229,4 +2229,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "0de23c7942f7fcc4e15d1937b6245d8cbc7be8e0a8336bdcb6314e9006a4e8e2"
+content-hash = "fa82ef7983e5183b8633fa9580c57d7572bc5b4329722951cd8789691eb89a1e"

--- a/packages/ni.measurements.data.v1.proto/pyproject.toml
+++ b/packages/ni.measurements.data.v1.proto/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ni.measurements.data.v1.proto"
-version = "1.1.0.dev2"
+version = "1.1.0"
 license = "MIT"
 description = "Protobuf data types and service stubs for NI data store gRPC APIs"
 authors = [{name = "NI", email = "opensource@ni.com"}]

--- a/packages/ni.measurements.data.v1.proto/pyproject.toml
+++ b/packages/ni.measurements.data.v1.proto/pyproject.toml
@@ -41,7 +41,7 @@ requires-poetry = '>=2.1,<3.0'
 protobuf = {version=">=4.21"}
 ni-datamonikers-v1-proto = { version = ">=1.0.0" }
 ni-measurements-metadata-v1-proto = { version = ">=1.0.0" }
-ni-protobuf-types = { version = ">=1.2.0.dev0", allow-prereleases = true }
+ni-protobuf-types = { version = ">=1.2.0", allow-prereleases = true }
 
 [tool.poetry.group.dev.dependencies]
 types-grpcio = ">=1.0"


### PR DESCRIPTION
### What does this Pull Request accomplish?

Bumps `ni.measurements.data.v1.proto` version to 1.1.0 and its `ni.protobuf.types` required version to 1.2.0.

### Why should this Pull Request be merged?

Prepare to release `ni.measurements.data.v1.proto` and ensure it depends only on released packages.

### What testing has been done?

Ran `poetry install` to verify no prerelease versions appeared.
