### PR TITLE
Add float waveform conversion methods and tests

### DIFF
--- a/packages/ni.protobuf.types/src/ni/protobuf/types/waveform_conversion.py
+++ b/packages/ni.protobuf.types/src/ni/protobuf/types/waveform_conversion.py
@@ -185,19 +185,19 @@ def float32_complex_waveform_to_protobuf(
 ) -> FloatComplexWaveform:
     """Convert the Python ComplexWaveform to a protobuf FloatComplexWaveform."""
     attributes = _extended_properties_to_attributes(value.extended_properties)
-    interleaved_array = value.scaled_data.view(np.float64)
+    interleaved_array = value.get_scaled_data(np.complex64).view(np.float32)
     if value.timing.sample_interval_mode in [SampleIntervalMode.REGULAR, SampleIntervalMode.NONE]:
         return FloatComplexWaveform(
             t0=_t0_from_waveform(value),
             dt=_time_interval_from_waveform(value),
-            y_data=interleaved_array,  # TODO: This is an array of 64bit values. Do we need to use raw_data or range check?
+            y_data=interleaved_array,
             attributes=attributes,
             timestamp=_timestamp_from_waveform(value),
             time_offset=_time_offset_from_waveform(value),
         )
     elif value.timing.sample_interval_mode == SampleIntervalMode.IRREGULAR:
         return FloatComplexWaveform(
-            y_data=interleaved_array,  # TODO: This is an array of 64bit values. Do we need to use raw_data or range check?
+            y_data=interleaved_array,
             attributes=attributes,
             timestamps=_timestamps_from_waveform(value),
         )

--- a/packages/ni.protobuf.types/src/ni/protobuf/types/waveform_conversion.py
+++ b/packages/ni.protobuf.types/src/ni/protobuf/types/waveform_conversion.py
@@ -105,14 +105,14 @@ def float32_analog_waveform_to_protobuf(
         return FloatAnalogWaveform(
             t0=_t0_from_waveform(value),
             dt=_time_interval_from_waveform(value),
-            y_data=value.scaled_data,  # TODO: scaled_data is 64bits. Do we need to use raw_data or range check?
+            y_data=value.get_scaled_data(np.float32),
             attributes=attributes,
             timestamp=_timestamp_from_waveform(value),
             time_offset=_time_offset_from_waveform(value),
         )
     elif value.timing.sample_interval_mode == SampleIntervalMode.IRREGULAR:
         return FloatAnalogWaveform(
-            y_data=value.scaled_data,  # TODO: scaled_data is 64bits. Do we need to use raw_data or range check?
+            y_data=value.get_scaled_data(np.float32),
             attributes=attributes,
             timestamps=_timestamps_from_waveform(value),
         )

--- a/packages/ni.protobuf.types/src/ni/protobuf/types/waveform_conversion.py
+++ b/packages/ni.protobuf.types/src/ni/protobuf/types/waveform_conversion.py
@@ -48,6 +48,8 @@ AnyNiWaveform: TypeAlias = AnalogWaveform[Any] | ComplexWaveform[Any] | DigitalW
 AnyWaveformProto: TypeAlias = (
     DoubleAnalogWaveform
     | DoubleComplexWaveform
+    | FloatAnalogWaveform
+    | FloatComplexWaveform
     | I16AnalogWaveform
     | I16ComplexWaveform
     | DigitalWaveformProto
@@ -103,14 +105,14 @@ def float32_analog_waveform_to_protobuf(
         return FloatAnalogWaveform(
             t0=_t0_from_waveform(value),
             dt=_time_interval_from_waveform(value),
-            y_data=value.scaled_data,  # TODO: scaled_data is 64bits. Do we need to range check or coerce here?
+            y_data=value.scaled_data,  # TODO: scaled_data is 64bits. Do we need to use raw_data or range check?
             attributes=attributes,
             timestamp=_timestamp_from_waveform(value),
             time_offset=_time_offset_from_waveform(value),
         )
     elif value.timing.sample_interval_mode == SampleIntervalMode.IRREGULAR:
         return FloatAnalogWaveform(
-            y_data=value.scaled_data,  # TODO: scaled_data is 64bits. Do we need to range check or coerce here?
+            y_data=value.scaled_data,  # TODO: scaled_data is 64bits. Do we need to use raw_data or range check?
             attributes=attributes,
             timestamps=_timestamps_from_waveform(value),
         )
@@ -188,14 +190,14 @@ def float32_complex_waveform_to_protobuf(
         return FloatComplexWaveform(
             t0=_t0_from_waveform(value),
             dt=_time_interval_from_waveform(value),
-            y_data=interleaved_array,  # TODO: This is an array of 64bit values. Do we need to range check or coerce?
+            y_data=interleaved_array,  # TODO: This is an array of 64bit values. Do we need to use raw_data or range check?
             attributes=attributes,
             timestamp=_timestamp_from_waveform(value),
             time_offset=_time_offset_from_waveform(value),
         )
     elif value.timing.sample_interval_mode == SampleIntervalMode.IRREGULAR:
         return FloatComplexWaveform(
-            y_data=interleaved_array,  # TODO: This is an array of 64bit values. Do we need to range check or coerce?
+            y_data=interleaved_array,  # TODO: This is an array of 64bit values. Do we need to use raw_data or range check?
             attributes=attributes,
             timestamps=_timestamps_from_waveform(value),
         )

--- a/packages/ni.protobuf.types/src/ni/protobuf/types/waveform_conversion.py
+++ b/packages/ni.protobuf.types/src/ni/protobuf/types/waveform_conversion.py
@@ -31,6 +31,9 @@ from ni.protobuf.types.waveform_pb2 import (
     DoubleAnalogWaveform,
     DoubleComplexWaveform,
     DoubleSpectrum,
+    FloatAnalogWaveform,
+    FloatComplexWaveform,
+    FloatSpectrum,
     I16AnalogWaveform,
     I16ComplexWaveform,
     LinearScale,
@@ -91,6 +94,46 @@ def float64_analog_waveform_from_protobuf(
     )
 
 
+def float32_analog_waveform_to_protobuf(
+    value: AnalogWaveform[np.float32], /
+) -> FloatAnalogWaveform:
+    """Convert the Python AnalogWaveform to a protobuf FloatAnalogWaveform."""
+    attributes = _extended_properties_to_attributes(value.extended_properties)
+    if value.timing.sample_interval_mode in [SampleIntervalMode.REGULAR, SampleIntervalMode.NONE]:
+        return FloatAnalogWaveform(
+            t0=_t0_from_waveform(value),
+            dt=_time_interval_from_waveform(value),
+            y_data=value.scaled_data,  # TODO: scaled_data is 64bits. Do we need to range check or coerce here?
+            attributes=attributes,
+            timestamp=_timestamp_from_waveform(value),
+            time_offset=_time_offset_from_waveform(value),
+        )
+    elif value.timing.sample_interval_mode == SampleIntervalMode.IRREGULAR:
+        return FloatAnalogWaveform(
+            y_data=value.scaled_data,  # TODO: scaled_data is 64bits. Do we need to range check or coerce here?
+            attributes=attributes,
+            timestamps=_timestamps_from_waveform(value),
+        )
+    else:
+        raise ValueError(f"Invalid sample interval mode: {value.timing.sample_interval_mode}")
+
+
+def float32_analog_waveform_from_protobuf(
+    message: FloatAnalogWaveform, /
+) -> AnalogWaveform[np.float32]:
+    """Convert the protobuf FloatAnalogWaveform to a Python AnalogWaveform."""
+    timing = _timing_from_waveform_message(message)
+    extended_properties = _attributes_to_extended_properties(message.attributes)
+
+    return AnalogWaveform.from_array_1d(
+        message.y_data,
+        dtype=np.float32,
+        extended_properties=extended_properties,
+        timing=timing,
+        scale_mode=NoneScaleMode(),
+    )
+
+
 def float64_complex_waveform_to_protobuf(
     value: ComplexWaveform[np.complex128], /
 ) -> DoubleComplexWaveform:
@@ -125,6 +168,50 @@ def float64_complex_waveform_from_protobuf(
 
     y_array = np.array(message.y_data, np.float64)
     data_array = y_array.view(np.complex128)
+
+    return ComplexWaveform.from_array_1d(
+        data_array,
+        copy=False,
+        extended_properties=extended_properties,
+        timing=timing,
+        scale_mode=NoneScaleMode(),
+    )
+
+
+def float32_complex_waveform_to_protobuf(
+    value: ComplexWaveform[np.complex64], /
+) -> FloatComplexWaveform:
+    """Convert the Python ComplexWaveform to a protobuf FloatComplexWaveform."""
+    attributes = _extended_properties_to_attributes(value.extended_properties)
+    interleaved_array = value.scaled_data.view(np.float64)
+    if value.timing.sample_interval_mode in [SampleIntervalMode.REGULAR, SampleIntervalMode.NONE]:
+        return FloatComplexWaveform(
+            t0=_t0_from_waveform(value),
+            dt=_time_interval_from_waveform(value),
+            y_data=interleaved_array,  # TODO: This is an array of 64bit values. Do we need to range check or coerce?
+            attributes=attributes,
+            timestamp=_timestamp_from_waveform(value),
+            time_offset=_time_offset_from_waveform(value),
+        )
+    elif value.timing.sample_interval_mode == SampleIntervalMode.IRREGULAR:
+        return FloatComplexWaveform(
+            y_data=interleaved_array,  # TODO: This is an array of 64bit values. Do we need to range check or coerce?
+            attributes=attributes,
+            timestamps=_timestamps_from_waveform(value),
+        )
+    else:
+        raise ValueError(f"Invalid sample interval mode: {value.timing.sample_interval_mode}")
+
+
+def float32_complex_waveform_from_protobuf(
+    message: FloatComplexWaveform, /
+) -> ComplexWaveform[np.complex64]:
+    """Convert the protobuf FloatComplexWaveform to a Python ComplexWaveform."""
+    timing = _timing_from_waveform_message(message)
+    extended_properties = _attributes_to_extended_properties(message.attributes)
+
+    y_array = np.array(message.y_data, np.float32)
+    data_array = y_array.view(np.complex64)
 
     return ComplexWaveform.from_array_1d(
         data_array,
@@ -200,6 +287,29 @@ def float64_spectrum_from_protobuf(message: DoubleSpectrum, /) -> Spectrum[np.fl
     return Spectrum.from_array_1d(
         message.data,
         dtype=np.float64,
+        start_frequency=message.start_frequency,
+        frequency_increment=message.frequency_increment,
+        extended_properties=extended_properties,
+    )
+
+
+def float32_spectrum_to_protobuf(value: Spectrum[np.float32], /) -> FloatSpectrum:
+    """Convert the Python Spectrum to a protobuf FloatSpectrum."""
+    attributes = _extended_properties_to_attributes(value.extended_properties)
+    return FloatSpectrum(
+        start_frequency=value.start_frequency,
+        frequency_increment=value.frequency_increment,
+        data=value.data,
+        attributes=attributes,
+    )
+
+
+def float32_spectrum_from_protobuf(message: FloatSpectrum, /) -> Spectrum[np.float32]:
+    """Convert the protobuf FloatSpectrum to a Python Spectrum."""
+    extended_properties = _attributes_to_extended_properties(message.attributes)
+    return Spectrum.from_array_1d(
+        message.data,
+        dtype=np.float32,
         start_frequency=message.start_frequency,
         frequency_increment=message.frequency_increment,
         extended_properties=extended_properties,

--- a/packages/ni.protobuf.types/tests/unit/test_spectrum_conversion.py
+++ b/packages/ni.protobuf.types/tests/unit/test_spectrum_conversion.py
@@ -2,19 +2,22 @@ import numpy as np
 from nitypes.waveform import Spectrum
 
 from ni.protobuf.types.waveform_conversion import (
+    float32_spectrum_from_protobuf,
+    float32_spectrum_to_protobuf,
     float64_spectrum_from_protobuf,
     float64_spectrum_to_protobuf,
 )
 from ni.protobuf.types.waveform_pb2 import (
     DoubleSpectrum,
+    FloatSpectrum,
     WaveformAttributeValue,
 )
 
 
 # ========================================================
-# Spectrum to DoubleSpectrum
+# Spectrum64 to DoubleSpectrum
 # ========================================================
-def test___default_spectrum___convert___valid_protobuf() -> None:
+def test___default_spectrum64___convert___valid_protobuf() -> None:
     spectrum = Spectrum()
 
     dbl_spectrum = float64_spectrum_to_protobuf(spectrum)
@@ -25,7 +28,7 @@ def test___default_spectrum___convert___valid_protobuf() -> None:
     assert list(dbl_spectrum.data) == []
 
 
-def test___spectrum_with_data___convert___valid_protobuf() -> None:
+def test___spectrum64_with_data___convert___valid_protobuf() -> None:
     spectrum = Spectrum.from_array_1d(np.array([1.0, 2.0, 3.0]))
     spectrum.start_frequency = 100.0
     spectrum.frequency_increment = 10.0
@@ -37,7 +40,7 @@ def test___spectrum_with_data___convert___valid_protobuf() -> None:
     assert dbl_spectrum.frequency_increment == 10.0
 
 
-def test___spectrum_with_extended_properties___convert___valid_protobuf() -> None:
+def test___spectrum64_with_extended_properties___convert___valid_protobuf() -> None:
     spectrum = Spectrum()
     spectrum.channel_name = "Dev1/ai0"
     spectrum.units = "Volts"
@@ -86,3 +89,83 @@ def test___dbl_spectrum_with_attributes___convert___valid_python_object() -> Non
 
     assert spectrum.channel_name == "Dev1/ai0"
     assert spectrum.units == "Volts"
+
+
+# ========================================================
+# Spectrum32 to FloatSpectrum
+# ========================================================
+def test___default_spectrum32___convert___valid_protobuf() -> None:
+    spectrum = Spectrum(dtype=np.float32)
+
+    float_spectrum = float32_spectrum_to_protobuf(spectrum)
+
+    assert not float_spectrum.attributes
+    assert spectrum.start_frequency == 0.0
+    assert spectrum.frequency_increment == 0.0
+    assert list(float_spectrum.data) == []
+
+
+def test___spectrum32_with_data___convert___valid_protobuf() -> None:
+    spectrum = Spectrum.from_array_1d(np.array([1.0, 2.0, 3.0]), dtype=np.float32)
+    spectrum.start_frequency = 100.0
+    spectrum.frequency_increment = 10.0
+
+    float_spectrum = float32_spectrum_to_protobuf(spectrum)
+
+    assert list(float_spectrum.data) == [1.0, 2.0, 3.0]
+    assert float_spectrum.start_frequency == 100.0
+    assert float_spectrum.frequency_increment == 10.0
+
+
+def test___spectrum32_with_extended_properties___convert___valid_protobuf() -> None:
+    spectrum = Spectrum(dtype=np.float32)
+    spectrum.channel_name = "Dev1/ai0"
+    spectrum.units = "Volts"
+
+    dbl_spectrum = float32_spectrum_to_protobuf(spectrum)
+
+    assert dbl_spectrum.attributes["NI_ChannelName"].string_value == "Dev1/ai0"
+    assert dbl_spectrum.attributes["NI_UnitDescription"].string_value == "Volts"
+
+
+# ========================================================
+# FloatSpectrum to Spectrum32
+# ========================================================
+def test___default_float_spectrum___convert___valid_python_object() -> None:
+    float_spectrum = FloatSpectrum()
+
+    spectrum = float32_spectrum_from_protobuf(float_spectrum)
+
+    assert not spectrum.extended_properties
+    assert spectrum.start_frequency == 0.0
+    assert spectrum.frequency_increment == 0.0
+    assert spectrum.sample_count == 0
+    assert spectrum.data.size == 0
+    assert spectrum.dtype == np.float32
+
+
+def test___float_spectrum_with_data___convert___valid_python_object() -> None:
+    float_spectrum = FloatSpectrum(
+        data=[1.0, 2.0, 3.0], start_frequency=100.0, frequency_increment=10.0
+    )
+
+    spectrum = float32_spectrum_from_protobuf(float_spectrum)
+
+    assert list(spectrum.data) == [1.0, 2.0, 3.0]
+    assert spectrum.start_frequency == 100.0
+    assert spectrum.frequency_increment == 10.0
+    assert spectrum.dtype == np.float32
+
+
+def test___float_spectrum_with_attributes___convert___valid_python_object() -> None:
+    attributes = {
+        "NI_ChannelName": WaveformAttributeValue(string_value="Dev1/ai0"),
+        "NI_UnitDescription": WaveformAttributeValue(string_value="Volts"),
+    }
+    float_spectrum = FloatSpectrum(attributes=attributes)
+
+    spectrum = float32_spectrum_from_protobuf(float_spectrum)
+
+    assert spectrum.channel_name == "Dev1/ai0"
+    assert spectrum.units == "Volts"
+    assert spectrum.dtype == np.float32

--- a/packages/ni.protobuf.types/tests/unit/test_spectrum_conversion.py
+++ b/packages/ni.protobuf.types/tests/unit/test_spectrum_conversion.py
@@ -23,8 +23,8 @@ def test___default_spectrum64___convert___valid_protobuf() -> None:
     dbl_spectrum = float64_spectrum_to_protobuf(spectrum)
 
     assert not dbl_spectrum.attributes
-    assert spectrum.start_frequency == 0.0
-    assert spectrum.frequency_increment == 0.0
+    assert dbl_spectrum.start_frequency == 0.0
+    assert dbl_spectrum.frequency_increment == 0.0
     assert list(dbl_spectrum.data) == []
 
 
@@ -122,10 +122,10 @@ def test___spectrum32_with_extended_properties___convert___valid_protobuf() -> N
     spectrum.channel_name = "Dev1/ai0"
     spectrum.units = "Volts"
 
-    dbl_spectrum = float32_spectrum_to_protobuf(spectrum)
+    float_spectrum = float32_spectrum_to_protobuf(spectrum)
 
-    assert dbl_spectrum.attributes["NI_ChannelName"].string_value == "Dev1/ai0"
-    assert dbl_spectrum.attributes["NI_UnitDescription"].string_value == "Volts"
+    assert float_spectrum.attributes["NI_ChannelName"].string_value == "Dev1/ai0"
+    assert float_spectrum.attributes["NI_UnitDescription"].string_value == "Volts"
 
 
 # ========================================================

--- a/packages/ni.protobuf.types/tests/unit/test_waveform_conversion.py
+++ b/packages/ni.protobuf.types/tests/unit/test_waveform_conversion.py
@@ -19,6 +19,10 @@ from ni.protobuf.types.waveform_conversion import (
     float64_analog_waveform_to_protobuf,
     float64_complex_waveform_from_protobuf,
     float64_complex_waveform_to_protobuf,
+    float32_analog_waveform_from_protobuf,
+    float32_analog_waveform_to_protobuf,
+    float32_complex_waveform_from_protobuf,
+    float32_complex_waveform_to_protobuf,
     int16_analog_waveform_from_protobuf,
     int16_analog_waveform_to_protobuf,
     int16_complex_waveform_from_protobuf,
@@ -28,6 +32,8 @@ from ni.protobuf.types.waveform_pb2 import (
     DigitalWaveform as DigitalWaveformProto,
     DoubleAnalogWaveform,
     DoubleComplexWaveform,
+    FloatAnalogWaveform,
+    FloatComplexWaveform,
     I16AnalogWaveform,
     I16ComplexWaveform,
     Scale,
@@ -111,6 +117,83 @@ class TestDoubleAnalogConversion(
         assert list(analog_waveform.scaled_data) == [1.0, 2.0, 3.0]
 
 
+class TestFloatAnalogConversion(
+    BaseWaveformConversionTests[AnalogWaveform[np.float32], FloatAnalogWaveform]
+):
+    """Test for converting float (single) analog waveforms to/from protobuf messages."""
+
+    def make_waveform(self) -> AnalogWaveform[np.float32]:
+        """Create a waveform with small non-zero sample data."""
+        return AnalogWaveform.from_array_1d(np.array([1.0, 2.0]))
+
+    def make_waveform_proto(
+        self,
+        attributes: Mapping[str, WaveformAttributeValue] | None = None,
+        scale: Scale | None = None,
+    ) -> FloatAnalogWaveform:
+        """Create a waveform protobuf object with small non-zero sample data."""
+        return FloatAnalogWaveform(y_data=[1.0, 2.0], attributes=attributes)
+
+    def to_protobuf(self, waveform: AnalogWaveform[np.float32]) -> FloatAnalogWaveform:
+        """Convert a Python waveform to its corresponding proto message."""
+        return float32_analog_waveform_to_protobuf(waveform)
+
+    def from_protobuf(self, waveform_proto: FloatAnalogWaveform) -> AnalogWaveform[np.float32]:
+        """Convert a proto message to the corresponding Python waveform."""
+        return float32_analog_waveform_from_protobuf(waveform_proto)
+
+    # ========================================================
+    # To Protobuf
+    # ========================================================
+    def test___default_analog_waveform___convert___valid_protobuf(self) -> None:
+        analog_waveform = AnalogWaveform(dtype=np.float32)
+
+        float_analog_waveform = float32_analog_waveform_to_protobuf(analog_waveform)
+
+        assert not float_analog_waveform.attributes
+        assert float_analog_waveform.dt == 0
+        assert not float_analog_waveform.HasField("t0")
+        assert list(float_analog_waveform.y_data) == []
+
+    def test___analog_waveform_samples_only___convert___valid_protobuf(self) -> None:
+        analog_waveform = AnalogWaveform(5, dtype=np.float32)
+
+        float_analog_waveform = float32_analog_waveform_to_protobuf(analog_waveform)
+
+        assert list(float_analog_waveform.y_data) == [0.0, 0.0, 0.0, 0.0, 0.0]
+
+    def test___analog_waveform_non_zero_samples___convert___valid_protobuf(self) -> None:
+        analog_waveform = AnalogWaveform.from_array_1d(np.array([1.0, 2.0, 3.0]), dtype=np.float32)
+
+        float_analog_waveform = float64_analog_waveform_to_protobuf(analog_waveform)
+
+        assert list(float_analog_waveform.y_data) == [1.0, 2.0, 3.0]
+
+    # ========================================================
+    # From Protobuf
+    # ========================================================
+    def test___default_float_analog_wfm___convert___valid_python_object(self) -> None:
+        float_analog_wfm = FloatAnalogWaveform()
+
+        analog_waveform = float32_analog_waveform_from_protobuf(float_analog_wfm)
+
+        print(analog_waveform.timing)
+        assert not analog_waveform.extended_properties
+        assert analog_waveform.timing.sample_interval_mode == SampleIntervalMode.NONE
+        assert analog_waveform.timing.time_offset == ht.timedelta()
+        assert analog_waveform.scaled_data.size == 0
+        assert analog_waveform.scale_mode == NoneScaleMode()
+        assert analog_waveform.dtype == np.float32
+
+    def test___float_analog_wfm_with_y_data___convert___valid_python_object(self) -> None:
+        float_analog_wfm = FloatAnalogWaveform(y_data=[1.0, 2.0, 3.0])
+
+        analog_waveform = float32_analog_waveform_from_protobuf(float_analog_wfm)
+
+        assert list(analog_waveform.scaled_data) == [1.0, 2.0, 3.0]
+        assert analog_waveform.dtype == np.float32
+
+
 class TestDoubleComplexWaveformConversion(
     BaseWaveformConversionTests[ComplexWaveform[np.complex128], DoubleComplexWaveform]
 ):
@@ -186,6 +269,85 @@ class TestDoubleComplexWaveformConversion(
         complex_waveform = float64_complex_waveform_from_protobuf(dbl_complex_waveform)
 
         assert list(complex_waveform.scaled_data) == [1.0 + 2.0j, 3.0 + 4.0j]
+
+
+class TestFloatComplexWaveformConversion(
+    BaseWaveformConversionTests[ComplexWaveform[np.complex64], FloatComplexWaveform]
+):
+    """Test for converting float (single) complex waveforms to/from protobuf messages."""
+
+    def make_waveform(self) -> ComplexWaveform[np.complex64]:
+        """Create a waveform with small non-zero sample data."""
+        return ComplexWaveform.from_array_1d([1.5 + 2.5j, 3.5 + 4.5j], np.complex64)
+
+    def make_waveform_proto(
+        self,
+        attributes: Mapping[str, WaveformAttributeValue] | None = None,
+        scale: Scale | None = None,
+    ) -> FloatComplexWaveform:
+        """Create a waveform protobuf object with small non-zero sample data."""
+        return FloatComplexWaveform(y_data=[1.0, 2.0, 3.0, 4.0], attributes=attributes)
+
+    def to_protobuf(self, waveform: ComplexWaveform[np.complex64]) -> FloatComplexWaveform:
+        """Convert a Python waveform to its corresponding proto message."""
+        return float32_complex_waveform_to_protobuf(waveform)
+
+    def from_protobuf(
+        self, waveform_proto: FloatComplexWaveform
+    ) -> ComplexWaveform[np.complex64]:
+        """Convert a proto message to the corresponding Python waveform."""
+        return float32_complex_waveform_from_protobuf(waveform_proto)
+
+    # ========================================================
+    # To Protobuf
+    # ========================================================
+    def test___default_float32_complex_waveform___convert___valid_protobuf(self) -> None:
+        complex_waveform = ComplexWaveform(0, np.complex64)
+
+        float_complex_waveform = float32_complex_waveform_to_protobuf(complex_waveform)
+
+        assert not float_complex_waveform.attributes
+        assert float_complex_waveform.dt == 0
+        assert not float_complex_waveform.HasField("t0")
+        assert list(float_complex_waveform.y_data) == []
+
+    def test___float32_complex_waveform_samples_only___convert___valid_protobuf(self) -> None:
+        complex_waveform = ComplexWaveform(2, np.complex64)
+
+        float_complex_waveform = float32_complex_waveform_to_protobuf(complex_waveform)
+
+        # Interleaved real/imaginary data.
+        assert list(float_complex_waveform.y_data) == [0.0, 0.0, 0.0, 0.0]
+
+    def test___float32_complex_waveform_non_zero_samples___convert___valid_protobuf(self) -> None:
+        complex_waveform = ComplexWaveform.from_array_1d([1.5 + 2.5j, 3.5 + 4.5j], np.complex64)
+
+        float_complex_waveform = float32_complex_waveform_to_protobuf(complex_waveform)
+
+        assert list(float_complex_waveform.y_data) == [1.5, 2.5, 3.5, 4.5]
+
+    # ========================================================
+    # From Protobuf
+    # ========================================================
+    def test___default_float_complex_wfm___convert___valid_python_object(self) -> None:
+        float_complex_waveform = FloatComplexWaveform()
+
+        complex_waveform = float32_complex_waveform_from_protobuf(float_complex_waveform)
+
+        assert not complex_waveform.extended_properties
+        assert complex_waveform.timing.sample_interval_mode == SampleIntervalMode.NONE
+        assert complex_waveform.timing.time_offset == ht.timedelta()
+        assert complex_waveform.scaled_data.size == 0
+        assert complex_waveform.scale_mode == NoneScaleMode()
+        assert complex_waveform.dtype == np.complex64
+
+    def test___float_complex_wfm_with_y_data___convert___valid_python_object(self) -> None:
+        float_complex_waveform = FloatComplexWaveform(y_data=[1.0, 2.0, 3.0, 4.0])
+
+        complex_waveform = float32_complex_waveform_from_protobuf(float_complex_waveform)
+
+        assert list(complex_waveform.scaled_data) == [1.0 + 2.0j, 3.0 + 4.0j]
+        assert complex_waveform.dtype == np.complex64
 
 
 class TestI16ComplexWaveformConversion(

--- a/packages/ni.protobuf.types/tests/unit/test_waveform_conversion.py
+++ b/packages/ni.protobuf.types/tests/unit/test_waveform_conversion.py
@@ -15,14 +15,14 @@ from nitypes.waveform import (
 from ni.protobuf.types.waveform_conversion import (
     digital_waveform_from_protobuf,
     digital_waveform_to_protobuf,
-    float64_analog_waveform_from_protobuf,
-    float64_analog_waveform_to_protobuf,
-    float64_complex_waveform_from_protobuf,
-    float64_complex_waveform_to_protobuf,
     float32_analog_waveform_from_protobuf,
     float32_analog_waveform_to_protobuf,
     float32_complex_waveform_from_protobuf,
     float32_complex_waveform_to_protobuf,
+    float64_analog_waveform_from_protobuf,
+    float64_analog_waveform_to_protobuf,
+    float64_complex_waveform_from_protobuf,
+    float64_complex_waveform_to_protobuf,
     int16_analog_waveform_from_protobuf,
     int16_analog_waveform_to_protobuf,
     int16_complex_waveform_from_protobuf,
@@ -124,7 +124,7 @@ class TestFloatAnalogConversion(
 
     def make_waveform(self) -> AnalogWaveform[np.float32]:
         """Create a waveform with small non-zero sample data."""
-        return AnalogWaveform.from_array_1d(np.array([1.0, 2.0]))
+        return AnalogWaveform.from_array_1d(np.array([1.0, 2.0]), dtype=np.float32)
 
     def make_waveform_proto(
         self,
@@ -165,7 +165,7 @@ class TestFloatAnalogConversion(
     def test___analog_waveform_non_zero_samples___convert___valid_protobuf(self) -> None:
         analog_waveform = AnalogWaveform.from_array_1d(np.array([1.0, 2.0, 3.0]), dtype=np.float32)
 
-        float_analog_waveform = float64_analog_waveform_to_protobuf(analog_waveform)
+        float_analog_waveform = float32_analog_waveform_to_protobuf(analog_waveform)
 
         assert list(float_analog_waveform.y_data) == [1.0, 2.0, 3.0]
 
@@ -292,9 +292,7 @@ class TestFloatComplexWaveformConversion(
         """Convert a Python waveform to its corresponding proto message."""
         return float32_complex_waveform_to_protobuf(waveform)
 
-    def from_protobuf(
-        self, waveform_proto: FloatComplexWaveform
-    ) -> ComplexWaveform[np.complex64]:
+    def from_protobuf(self, waveform_proto: FloatComplexWaveform) -> ComplexWaveform[np.complex64]:
         """Convert a proto message to the corresponding Python waveform."""
         return float32_complex_waveform_from_protobuf(waveform_proto)
 

--- a/packages/ni.protobuf.types/tests/unit/test_waveform_conversion.py
+++ b/packages/ni.protobuf.types/tests/unit/test_waveform_conversion.py
@@ -102,7 +102,6 @@ class TestDoubleAnalogConversion(
 
         analog_waveform = float64_analog_waveform_from_protobuf(dbl_analog_wfm)
 
-        print(analog_waveform.timing)
         assert not analog_waveform.extended_properties
         assert analog_waveform.timing.sample_interval_mode == SampleIntervalMode.NONE
         assert analog_waveform.timing.time_offset == ht.timedelta()
@@ -177,7 +176,6 @@ class TestFloatAnalogConversion(
 
         analog_waveform = float32_analog_waveform_from_protobuf(float_analog_wfm)
 
-        print(analog_waveform.timing)
         assert not analog_waveform.extended_properties
         assert analog_waveform.timing.sample_interval_mode == SampleIntervalMode.NONE
         assert analog_waveform.timing.time_offset == ht.timedelta()


### PR DESCRIPTION
### What does this Pull Request accomplish?

[Changes were recently made](https://github.com/ni/ni-apis/pull/183) to `ni-apis` to add new float waveform and spectrum types that will be used by the RF InstrumentStudio panels. This PR updates `ni.protobufs.types` to add conversion methods and tests for these new message classes:
- FloatAnalogWaveform
- FloatComplexWaveform
- FloatSpectrum

### Why should this Pull Request be merged?

[AB#3985023](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3985023)
[AB#3985037](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3985037)

We need to expose these conversion methods via `ni.protobuf.types` so that the MDS python API can support the new types.

### What testing has been done?

- Unit tests added
- Unit tests pass
