### PR TITLE
Update package minor version and protobuf dependency

### DIFF
--- a/packages/ni.measurements.data.v1.proto/poetry.lock
+++ b/packages/ni.measurements.data.v1.proto/poetry.lock
@@ -1123,7 +1123,7 @@ url = "../ni.measurements.metadata.v1.proto"
 
 [[package]]
 name = "ni-protobuf-types"
-version = "1.2.1.dev0"
+version = "1.3.0.dev1"
 description = "Protobuf data types for NI gRPC APIs"
 optional = false
 python-versions = ">=3.10,<4.0"
@@ -2270,4 +2270,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "fa82ef7983e5183b8633fa9580c57d7572bc5b4329722951cd8789691eb89a1e"
+content-hash = "5658fe1f9fb3e94923104d1e26259ef12fbe358e96f1571bed95f4ba59285b3d"

--- a/packages/ni.measurements.data.v1.proto/pyproject.toml
+++ b/packages/ni.measurements.data.v1.proto/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ni.measurements.data.v1.proto"
-version = "1.1.1.dev0"
+version = "1.2.0.dev0"
 license = "MIT"
 description = "Protobuf data types and service stubs for NI data store gRPC APIs"
 authors = [{name = "NI", email = "opensource@ni.com"}]
@@ -41,7 +41,7 @@ requires-poetry = '>=2.1,<3.0'
 protobuf = {version=">=4.21"}
 ni-datamonikers-v1-proto = { version = ">=1.0.0" }
 ni-measurements-metadata-v1-proto = { version = ">=1.0.0" }
-ni-protobuf-types = { version = ">=1.2.0", allow-prereleases = true }
+ni-protobuf-types = { version = ">=1.3.0.dev0", allow-prereleases = true }
 
 [tool.poetry.group.dev.dependencies]
 types-grpcio = ">=1.0"


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Updates the minor version of the `ni.measurements.data.v1.proto` package since we've added new float waveform types.
- Updates the `ni-protobuf-types` dependency to `>=1.3.0.dev0` which is the version we just published that contains the new float waveform types. The generated code in this package will require this updated version of `ni-protobuf-types` when consumed by `ni.measurements.data.v1.client`.

### Why should this Pull Request be merged?

[AB#3985023](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3985023)
[AB#3985045](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3985045)

We want to pass these new float waveform types up the ni-apis-python dependency chain to be consumed by `ni.measurements.data.v1.client1`.

### What testing has been done?

PR checks.
