### PR TITLE
Update ni.measurements.data.v1.client minor version and update .proto dependency

### DIFF
--- a/packages/ni.measurements.data.v1.client/poetry.lock
+++ b/packages/ni.measurements.data.v1.client/poetry.lock
@@ -1224,7 +1224,7 @@ protobuf = ">=4.21"
 
 [[package]]
 name = "ni-measurements-data-v1-proto"
-version = "1.1.1.dev0"
+version = "1.2.0.dev0"
 description = "Protobuf data types and service stubs for NI data store gRPC APIs"
 optional = false
 python-versions = ">=3.10,<4.0"
@@ -1235,7 +1235,7 @@ develop = true
 [package.dependencies]
 ni-datamonikers-v1-proto = ">=1.0.0"
 ni-measurements-metadata-v1-proto = ">=1.0.0"
-ni-protobuf-types = ">=1.2.0"
+ni-protobuf-types = ">=1.3.0.dev0"
 protobuf = ">=4.21"
 
 [package.source]
@@ -1261,7 +1261,7 @@ url = "../ni.measurements.metadata.v1.proto"
 
 [[package]]
 name = "ni-protobuf-types"
-version = "1.2.1.dev0"
+version = "1.3.0.dev1"
 description = "Protobuf data types for NI gRPC APIs"
 optional = false
 python-versions = ">=3.10,<4.0"
@@ -2453,4 +2453,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "52bf19548e93fded416376bd705348dc7b4cde57764d7c49e7288963daa8c754"
+content-hash = "af039283fffdd1e4afde381a720732361b3e88fdc2f419d29a960b23dc342b09"

--- a/packages/ni.measurements.data.v1.client/pyproject.toml
+++ b/packages/ni.measurements.data.v1.client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ni.measurements.data.v1.client"
-version = "1.1.1.dev0"
+version = "1.2.0.dev0"
 license = "MIT"
 description = "gRPC Client for NI Data Store Service"
 authors = [{name = "NI", email = "opensource@ni.com"}]
@@ -38,7 +38,7 @@ requires-poetry = '>=2.1,<3.0'
 
 [tool.poetry.dependencies]
 ni-measurementlink-discovery-v1-client = { version = ">=1.1.0" }
-ni-measurements-data-v1-proto = { version = ">=1.1.0", allow-prereleases = true }
+ni-measurements-data-v1-proto = { version = ">=1.2.0.dev0", allow-prereleases = true }
 
 [tool.poetry.group.dev.dependencies]
 types-grpcio = ">=1.0"


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Updates the minor version of the `ni.measurements.data.v1.client` package since we've added new float waveform types.
- Updates the `ni.measurements.data.v1.proto` dependency to `>=1.2.0.dev0` which is the version we just published that contains the generated code for the new float waveform types.

### Why should this Pull Request be merged?

[AB#3985023](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3985023)
[AB#3985045](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3985045)

We want to expose these new float waveform types from the `ni.measurements.data.v1.client` API so that we can consume them in the `datastore-python` repo.

### What testing has been done?

PR checks.
